### PR TITLE
Change hardcoded links from IBM to merative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file
 
 ### Fixed
 
-* Removed the WebSphere Liberty dataSource setting `isolationLevel="TRANSACTION_REPEATABLE_READ"` [#109](https://github.com/IBM/spm-kubernetes/issues/109) as the default Liberty setting is appropriate for Db2 and Oracle
+* Removed the WebSphere Liberty dataSource setting `isolationLevel="TRANSACTION_REPEATABLE_READ"` [#109](https://github.com/merative/spm-kubernetes/issues/109) as the default Liberty setting is appropriate for Db2 and Oracle
 
 ### Breaking Change
 
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file
   * Modify the Prometheus namespace from `xmlserver_` to `curam_xmlserver` and restructure the counters, using a single jobs_total with labels:
     * `type` = `PDF|HTML|TEXT|RTF`
     * `status` = `fail|success`
-  * The [Monitoring XML servers](https://ibm.github.io/spm-kubernetes/monitoring/xmlserver-monitoring/) section of the Runbook has been modified to reflect the above changes.
+  * The [Monitoring XML servers](https://merative.github.io/spm-kubernetes/monitoring/xmlserver-monitoring/) section of the Runbook has been modified to reflect the above changes.
 
 ## v22.2.0
 
@@ -90,8 +90,8 @@ All notable changes to this project will be documented in this file
 ### Fixed
 
 * Fixed the issue where `xmlserver` pod termination overwrote the `verbosegc.log` written to by the `main` Ant task.
-* Clarified statement for `wlp_psw` in `values.yaml` and yaml examples ([#92](https://github.com/IBM/spm-kubernetes/issues/92))
-* Corrected `kubeVersion` ([#94](https://github.com/IBM/spm-kubernetes/issues/94))
+* Clarified statement for `wlp_psw` in `values.yaml` and yaml examples ([#92](https://github.com/merative/spm-kubernetes/issues/92))
+* Corrected `kubeVersion` ([#94](https://github.com/merative/spm-kubernetes/issues/94))
 
 ## v21.10.0
 
@@ -150,11 +150,11 @@ All notable changes to this project will be documented in this file
 * The following helm-charts have been updated to chart version `21.8.0`: `apps`, `batch`, `mqserver`, `spm`, `uawebapp`, `web`, `xmlserver`
 * Changed DB2 datasources isolation level for the `apps` producer and consumers pods. See [Transaction control/Underlying design/DB2/Repeatable Read](https://www.ibm.com/docs/en/spm/8.0.1?topic=design-db2)
 * Updated IBM Documentation link to SPM V8
-* Clarified prerequisite software statements ([#83](https://github.com/IBM/spm-kubernetes/issues/83))
+* Clarified prerequisite software statements ([#83](https://github.com/merative/spm-kubernetes/issues/83))
 
 ### Fixed
 
-* Update Oracle Database driver name to `ojdbc8.jar` ([#84](https://github.com/IBM/spm-kubernetes/issues/84))
+* Update Oracle Database driver name to `ojdbc8.jar` ([#84](https://github.com/merative/spm-kubernetes/issues/84))
 * Fixed issue where MQ pods deployed by MQ Operator on Openshift were not respecting tuning params
 
 ### Removed
@@ -245,7 +245,7 @@ All notable changes to this project will be documented in this file
 
 ### Fixed
 
-* Fixed reference to Oracle datasource fragment ([#78](https://github.com/IBM/spm-kubernetes/issues/78))
+* Fixed reference to Oracle datasource fragment ([#78](https://github.com/merative/spm-kubernetes/issues/78))
 
 ## v21.5.0
 
@@ -256,7 +256,7 @@ All notable changes to this project will be documented in this file
 * Added information in the **MustGather** introduction page about Helm Charts and Dockerfiles
 * Added capability to tune various database and JMS tuning parameters for individual producers and consumers
   * Created tuning-values.yaml as example.
-* Added capability for Docker Hub details to be used to avoid **toomanyrequests** ([#69](https://github.com/IBM/spm-kubernetes/issues/69))
+* Added capability for Docker Hub details to be used to avoid **toomanyrequests** ([#69](https://github.com/merative/spm-kubernetes/issues/69))
 * Added capability to set applications properties at deployment
 
 ### Changed
@@ -264,7 +264,7 @@ All notable changes to this project will be documented in this file
 * Allows for the simultaneous scraping of multiple metrics sources (eg JMX and Liberty) on `apps` charts
 * Moved `HTTPSessionDatabase` default configuration to timer based
 * Update `unzip` when unpacking the client EAR file
-* Ensure MQ directory structure exists, when using NFS ([#31](https://github.com/IBM/spm-kubernetes/issues/31))
+* Ensure MQ directory structure exists, when using NFS ([#31](https://github.com/merative/spm-kubernetes/issues/31))
 * Upgrade to Gatsby v3 (and associated dependencies)
 
 ## v21.4.1
@@ -282,8 +282,8 @@ All notable changes to this project will be documented in this file
 ### Changed
 
 * Changed the OpenShift reference architecture diagram to provide additional clarity regarding the statefulsets
-* Improved pod labels for compatibility with service meshes ([#61](https://github.com/IBM/spm-kubernetes/issues/61))
-* Improved navigation links to avoid 404 errors ([#68](https://github.com/IBM/spm-kubernetes/issues/68))
+* Improved pod labels for compatibility with service meshes ([#61](https://github.com/merative/spm-kubernetes/issues/61))
+* Improved navigation links to avoid 404 errors ([#68](https://github.com/merative/spm-kubernetes/issues/68))
 
 ### Removed
 
@@ -324,7 +324,7 @@ All notable changes to this project will be documented in this file
 
 ### Fixed
 
-* Certificate Error when logging in to the Open Shift Registry. Added clarification on enabling Docker trust certificates ([#58](https://github.com/IBM/spm-kubernetes/issues/58))
+* Certificate Error when logging in to the Open Shift Registry. Added clarification on enabling Docker trust certificates ([#58](https://github.com/merative/spm-kubernetes/issues/58))
 * Supporting the rotation of the `apps` logs
 
 ## v21.1.0
@@ -339,14 +339,14 @@ All notable changes to this project will be documented in this file
 ### Changed
 
 * Limit allowed HTTP verbs as detailed in the [IBM Documentation](https://www.ibm.com/docs/en/spm/7.0.11?topic=considerations-enabling-http-verb-permissions)
-* Set `-Xshareclasses` to `none` for Liberty-based images as workaround for OpenJ9 issue ([#51](https://github.com/IBM/spm-kubernetes/issues/51))
+* Set `-Xshareclasses` to `none` for Liberty-based images as workaround for OpenJ9 issue ([#51](https://github.com/merative/spm-kubernetes/issues/51))
 * Adds values from `podAnnotations` at deployment of `apps` chart
 
 ### Fixed
 
-* Added clarification that NFS folders must be configured prior to using MQ with NFS ([#31](https://github.com/IBM/spm-kubernetes/issues/31))
-* Added `mountOptions` configuration to `mqserver` PVs ([#30](https://github.com/IBM/spm-kubernetes/issues/30))
-* Synchronised handling of MQ TLS certificate secrets between `apps` and `mqserver` charts ([#28](https://github.com/IBM/spm-kubernetes/issues/28))
+* Added clarification that NFS folders must be configured prior to using MQ with NFS ([#31](https://github.com/merative/spm-kubernetes/issues/31))
+* Added `mountOptions` configuration to `mqserver` PVs ([#30](https://github.com/merative/spm-kubernetes/issues/30))
+* Synchronised handling of MQ TLS certificate secrets between `apps` and `mqserver` charts ([#28](https://github.com/merative/spm-kubernetes/issues/28))
 
 ## v20.11.0
 
@@ -356,7 +356,7 @@ All notable changes to this project will be documented in this file
 * Add a route in OpenShift to allow connections to SSO, when enabled
 * Updated the `ServerEAR.Dockerfile` to reduce layers
 * Added note with fix needed for an update in IBM MQ, the details of which can be found
-[here](https://github.com/IBM/charts/blob/master/stable/ibm-mqadvanced-server-dev/RELEASENOTES.md)
+[here](https://github.com/merative/charts/blob/master/stable/ibm-mqadvanced-server-dev/RELEASENOTES.md)
 * Added links to Architecture and Troubleshooting sections from within the flow of the document
 
 ### Changed
@@ -478,7 +478,7 @@ All notable changes to this project will be documented in this file
 ### Fixed
 
 * InitContainer for Batch does not meet pod security policy requirements
-* Missing Batch debug-file configmap ([#29](https://github.com/IBM/spm-kubernetes/issues/29))
+* Missing Batch debug-file configmap ([#29](https://github.com/merative/spm-kubernetes/issues/29))
 * Fixed Helm Chart syntax for enabling JMX Stats
 
 ### Removed
@@ -490,7 +490,7 @@ All notable changes to this project will be documented in this file
 ### Added
 
 * Integration with [IBM Security Access manager](https://www.ibm.com/ie-en/marketplace/access-management/details)
-* Dependency on IBM [Shared Configuration Helper](https://github.com/IBM/charts/tree/master/samples/ibm-sch) (SCH) chart for aligning with CloudPak code standards
+* Dependency on IBM [Shared Configuration Helper](https://github.com/merative/charts/tree/master/samples/ibm-sch) (SCH) chart for aligning with CloudPak code standards
 * Dockerfile for a utilities image (used as init containers to import certificates into keystores & wait for other components to become available)
 * Chart hooks for managing LTPA keys and MQ client user
 * Liberty runtime liveness probe (checks log for specific error messages)
@@ -519,9 +519,9 @@ All notable changes to this project will be documented in this file
 
 ### Fixed
 
-* Incorrect formatting of heredoc in `createSSC.sh` ([#24](https://github.com/IBM/spm-kubernetes/issues/24))
-* Db2 dependency in `spm/requirements.yaml` ([#23](https://github.com/IBM/spm-kubernetes/issues/23))
-* Duplicate `ihs` elements in `spm/values.yaml` ([#15](https://github.com/IBM/spm-kubernetes/issues/15))
+* Incorrect formatting of heredoc in `createSSC.sh` ([#24](https://github.com/merative/spm-kubernetes/issues/24))
+* Db2 dependency in `spm/requirements.yaml` ([#23](https://github.com/merative/spm-kubernetes/issues/23))
+* Duplicate `ihs` elements in `spm/values.yaml` ([#15](https://github.com/merative/spm-kubernetes/issues/15))
 
 ### Removed
 
@@ -554,7 +554,7 @@ All notable changes to this project will be documented in this file
 
 ### Fixed
 
-* [Broken Links in Prerequisites.](https://github.com/IBM/spm-kubernetes/issues/18)
+* [Broken Links in Prerequisites.](https://github.com/merative/spm-kubernetes/issues/18)
 
 ## v20.5.0 ![SPM 7.0.10.0](https://img.shields.io/badge/-SPM_7.0.10.0-green)
 
@@ -565,10 +565,10 @@ All notable changes to this project will be documented in this file
 
 ### Fixed
 
-* [helm commands not working.](https://github.com/IBM/spm-kubernetes/issues/6)
-* [ChartMuseum links broken.](https://github.com/IBM/spm-kubernetes/issues/7)
-* [Documentation correction for license check.](https://github.com/IBM/spm-kubernetes/issues/10)
-* [Helm dependency for ce-app needs conditional adding.](https://github.com/IBM/spm-kubernetes/issues/13)
-* [CE Ingress controller Rules created when the Application isn't deployed.](https://github.com/IBM/spm-kubernetes/issues/14)
-* [Duplicate ihs elements in spm/values.yaml.](https://github.com/IBM/spm-kubernetes/issues/15)
+* [helm commands not working.](https://github.com/merative/spm-kubernetes/issues/6)
+* [ChartMuseum links broken.](https://github.com/merative/spm-kubernetes/issues/7)
+* [Documentation correction for license check.](https://github.com/merative/spm-kubernetes/issues/10)
+* [Helm dependency for ce-app needs conditional adding.](https://github.com/merative/spm-kubernetes/issues/13)
+* [CE Ingress controller Rules created when the Application isn't deployed.](https://github.com/merative/spm-kubernetes/issues/14)
+* [Duplicate ihs elements in spm/values.yaml.](https://github.com/merative/spm-kubernetes/issues/15)
 * Addition of heapSize parameter in batch chart to allow for custom heap size specification

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This repository contains the assets and the runbook to follow to containerized SPM.
 
-The runbook is available at this URL: https://ibm.github.io/spm-kubernetes/
+The runbook is available at this URL: https://merative.github.io/spm-kubernetes/

--- a/helm-charts/apps/Chart.yaml
+++ b/helm-charts/apps/Chart.yaml
@@ -33,9 +33,9 @@ version: 22.4.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team
-    url: https://github.com/IBM/spm-kubernetes
+    url: https://github.com/merative/spm-kubernetes
 sources:
-  - https://github.com/IBM/spm-kubernetes
+  - https://github.com/merative/spm-kubernetes
 keywords:
   - Liberty
   - Minikube

--- a/helm-charts/apps/README.md
+++ b/helm-charts/apps/README.md
@@ -33,4 +33,4 @@ Not required as the underlying WebSphere Liberty server runs with the default re
 
 ## Configuration
 
-See [Configuration reference](https://ibm.github.io/spm-kubernetes/deployment/config-reference) section of the runbook.
+See [Configuration reference](https://merative.github.io/spm-kubernetes/deployment/config-reference) section of the runbook.

--- a/helm-charts/batch/Chart.yaml
+++ b/helm-charts/batch/Chart.yaml
@@ -33,9 +33,9 @@ version: 22.4.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team
-    url: https://github.com/IBM/spm-kubernetes
+    url: https://github.com/merative/spm-kubernetes
 sources:
-  - https://github.com/IBM/spm-kubernetes
+  - https://github.com/merative/spm-kubernetes
 keywords:
   - Liberty
   - Minikube

--- a/helm-charts/batch/README.md
+++ b/helm-charts/batch/README.md
@@ -31,4 +31,4 @@ Not required as the underlying IHS server runs with the default restricted polic
 
 ## Configuration
 
-See [Configuration reference](https://ibm.github.io/spm-kubernetes/deployment/config-reference) section of the runbook.
+See [Configuration reference](https://merative.github.io/spm-kubernetes/deployment/config-reference) section of the runbook.

--- a/helm-charts/mqserver/Chart.yaml
+++ b/helm-charts/mqserver/Chart.yaml
@@ -33,9 +33,9 @@ version: 22.4.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team
-    url: https://github.com/IBM/spm-kubernetes
+    url: https://github.com/merative/spm-kubernetes
 sources:
-  - https://github.com/IBM/spm-kubernetes
+  - https://github.com/merative/spm-kubernetes
 keywords:
   - Liberty
   - Minikube

--- a/helm-charts/mqserver/README.md
+++ b/helm-charts/mqserver/README.md
@@ -33,4 +33,4 @@ Not required as the underlying db2 instance runs with the default restricted pol
 
 ## Configuration
 
-See [Configuration reference](https://ibm.github.io/spm-kubernetes/deployment/config-reference) section of the runbook.
+See [Configuration reference](https://merative.github.io/spm-kubernetes/deployment/config-reference) section of the runbook.

--- a/helm-charts/spm/Chart.yaml
+++ b/helm-charts/spm/Chart.yaml
@@ -34,9 +34,9 @@ version: 22.4.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team
-    url: https://github.com/IBM/spm-kubernetes
+    url: https://github.com/merative/spm-kubernetes
 sources:
-  - https://github.com/IBM/spm-kubernetes
+  - https://github.com/merative/spm-kubernetes
 keywords:
   - Liberty
   - Minikube

--- a/helm-charts/spm/README.md
+++ b/helm-charts/spm/README.md
@@ -38,4 +38,4 @@ None
 
 ## Configuration
 
-See [Configuration reference](https://ibm.github.io/spm-kubernetes/deployment/config-reference) section of the runbook.
+See [Configuration reference](https://merative.github.io/spm-kubernetes/deployment/config-reference) section of the runbook.

--- a/helm-charts/uawebapp/Chart.yaml
+++ b/helm-charts/uawebapp/Chart.yaml
@@ -34,9 +34,9 @@ version: 22.4.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team
-    url: https://github.com/IBM/spm-kubernetes
+    url: https://github.com/merative/spm-kubernetes
 sources:
-  - https://github.com/IBM/spm-kubernetes
+  - https://github.com/merative/spm-kubernetes
 keywords:
   - Liberty
   - Minikube

--- a/helm-charts/uawebapp/README.md
+++ b/helm-charts/uawebapp/README.md
@@ -32,4 +32,4 @@ Not required as the underlying IHS server runs with the default restricted polic
 
 ## Configuration
 
-See [Configuration reference](https://ibm.github.io/spm-kubernetes/deployment/config-reference) section of the runbook.
+See [Configuration reference](https://merative.github.io/spm-kubernetes/deployment/config-reference) section of the runbook.

--- a/helm-charts/web/Chart.yaml
+++ b/helm-charts/web/Chart.yaml
@@ -33,9 +33,9 @@ version: 22.4.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team
-    url: https://github.com/IBM/spm-kubernetes
+    url: https://github.com/merative/spm-kubernetes
 sources:
-  - https://github.com/IBM/spm-kubernetes
+  - https://github.com/merative/spm-kubernetes
 keywords:
   - Liberty
   - Minikube

--- a/helm-charts/web/README.md
+++ b/helm-charts/web/README.md
@@ -33,4 +33,4 @@ Not required as web server runs with the default restricted policy
 
 ## Configuration
 
-See [Configuration reference](https://ibm.github.io/spm-kubernetes/deployment/config-reference) section of the runbook.
+See [Configuration reference](https://merative.github.io/spm-kubernetes/deployment/config-reference) section of the runbook.

--- a/helm-charts/xmlserver/Chart.yaml
+++ b/helm-charts/xmlserver/Chart.yaml
@@ -34,9 +34,9 @@ version: 22.4.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team
-    url: https://github.com/IBM/spm-kubernetes
+    url: https://github.com/merative/spm-kubernetes
 sources:
-  - https://github.com/IBM/spm-kubernetes
+  - https://github.com/merative/spm-kubernetes
 keywords:
   - Liberty
   - Minikube

--- a/helm-charts/xmlserver/README.md
+++ b/helm-charts/xmlserver/README.md
@@ -34,4 +34,4 @@ Not required as XML server runs with the default restricted policy
 
 ## Configuration
 
-See [Configuration reference](https://ibm.github.io/spm-kubernetes/deployment/config-reference) section of the runbook.
+See [Configuration reference](https://merative.github.io/spm-kubernetes/deployment/config-reference) section of the runbook.

--- a/src/gatsby-theme-carbon/components/LeftNav/ResourceLinks.js
+++ b/src/gatsby-theme-carbon/components/LeftNav/ResourceLinks.js
@@ -4,7 +4,7 @@ import ResourceLinks from 'gatsby-theme-carbon/src/components/LeftNav/ResourceLi
 const links = [
   {
     title: 'Github',
-    href: 'https://github.com/IBM/spm-kubernetes',
+    href: 'https://github.com/merative/spm-kubernetes',
   },
   {
     title: 'IBM Documentation',
@@ -12,7 +12,7 @@ const links = [
   },
   {
     title: 'Change Log',
-    href: 'https://github.com/IBM/spm-kubernetes/blob/main/CHANGELOG.md',
+    href: 'https://github.com/merative/spm-kubernetes/blob/main/CHANGELOG.md',
   }
 ];
 

--- a/src/pages/build-images/base_images.mdx
+++ b/src/pages/build-images/base_images.mdx
@@ -30,7 +30,7 @@ export DOCKER_BUILDKIT=0
 * Clone repository and change into the working directory:
 
   ```shell
-  git clone https://github.com/ibmruntimes/ci.docker.git
+  git clone https://github.com/merativeruntimes/ci.docker.git
   cd ci.docker/ibmjava/tests
   ```
 

--- a/src/pages/contact/contact_us.mdx
+++ b/src/pages/contact/contact_us.mdx
@@ -8,7 +8,7 @@ If you have feedback, or wish to raise an issue and you are not an IBM®
 
 To submit an issue or provide feedback, please create
  an issue
- [here](https://github.com/IBM/spm-kubernetes/issues).
+ [here](https://github.com/merative/spm-kubernetes/issues).
 We strongly suggest that you click Watch or Star the repository on
  GitHub to be updated about the latest changes.
 

--- a/src/pages/contributing.mdx
+++ b/src/pages/contributing.mdx
@@ -35,8 +35,8 @@ This is a guide for contributing to the SPM DevOps runbook.
 * [Install and Setup GitHub Desktop](https://services.github.com/on-demand/github-desktop/install-github-desktop) on your laptop
 * [Sign into GitHub from GitHub Desktop](https://help.github.com/desktop/guides/getting-started-with-github-desktop/authenticating-to-github/)
 * Learn [Markdown Syntax](https://guides.github.com/features/mastering-markdown/) and notice the formatting standards in the existing docs for examples of how we want you to construct a page
-* [Clone this repository](https://github.com/IBM/spm-kubernetes) to your local workstation from the GitHub UI or [use GitHub Desktop](https://services.github.com/on-demand/github-desktop/clone-repository-github-desktop)
-* [Create a branch](https://services.github.com/on-demand/github-desktop/create-branches-github-desktop) from the [main branch](https://github.com/IBM/spm-kubernetes/tree/main)
+* [Clone this repository](https://github.com/merative/spm-kubernetes) to your local workstation from the GitHub UI or [use GitHub Desktop](https://services.github.com/on-demand/github-desktop/clone-repository-github-desktop)
+* [Create a branch](https://services.github.com/on-demand/github-desktop/create-branches-github-desktop) from the [main branch](https://github.com/merative/spm-kubernetes/tree/main)
 
 ## Authoring
 

--- a/src/pages/deploy-spm/build-spm.mdx
+++ b/src/pages/deploy-spm/build-spm.mdx
@@ -112,7 +112,7 @@ build.bat configtest
 
 **Note:** When running the `configtest` Ant target you may experience a failed build with an `Unsupported version:` error in relation to the WebSphere Liberty version.
 
-If this happens please refer to the [Prerequisite software](https://ibm.github.io/spm-kubernetes/prereq/prereq/) for the correct list of supported WebSphere Liberty versions.
+If this happens please refer to the [Prerequisite software](https://merative.github.io/spm-kubernetes/prereq/prereq/) for the correct list of supported WebSphere Liberty versions.
 
 </InlineNotification>
 

--- a/src/pages/deployment/hc_deployment.mdx
+++ b/src/pages/deployment/hc_deployment.mdx
@@ -68,7 +68,7 @@ global:
         supplementalGroups: [888]
 ```
 
-This is due to a update in IBM MQ, the details of which can be found [here](https://github.com/IBM/charts/blob/master/stable/ibm-mqadvanced-server-dev/RELEASENOTES.md).
+This is due to a update in IBM MQ, the details of which can be found [here](https://github.com/merative/charts/blob/master/stable/ibm-mqadvanced-server-dev/RELEASENOTES.md).
 
 </InlineNotification>
 

--- a/src/pages/deployment/hc_preparation.mdx
+++ b/src/pages/deployment/hc_preparation.mdx
@@ -9,7 +9,7 @@ description: Preparing Helm charts
 
 </InlineNotification>
 
-The [spm-kubernetes](https://github.com/IBM/spm-kubernetes) repository provides the following Helm charts:
+The [spm-kubernetes](https://github.com/merative/spm-kubernetes) repository provides the following Helm charts:
 
 * *apps:* defines how to deploy the IBM® WebSphere® Liberty images with IBM® Cúram Social Program Management (SPM).
 * *batch:* defines the batch image configuration.
@@ -31,7 +31,7 @@ Before you run the charts, you must configure the database, configure IBM MQ, re
 You may also optionally integrate your deployment with an ISAM server for SSO enablement,
 to do so complete the steps on the [Enabling ISAM](/supporting-infrastructure/ISAM) page under Supporting Infrastructure before returning here.
 
-Many of the Helm charts that make up a deployment of SPM depend on the [IBM Shared Configuration Helpers](https://github.com/IBM/charts/tree/master/samples/ibm-sch) chart, so an extra Helm repository must be added using the following command:
+Many of the Helm charts that make up a deployment of SPM depend on the [IBM Shared Configuration Helpers](https://github.com/merative/charts/tree/master/samples/ibm-sch) chart, so an extra Helm repository must be added using the following command:
 
 ```shell
 helm repo add sch https://raw.githubusercontent.com/IBM/charts/master/repo/samples

--- a/src/pages/known_issues.mdx
+++ b/src/pages/known_issues.mdx
@@ -31,7 +31,7 @@ global:
         supplementalGroups: [888]
 ```
 
-This is due to a update in IBM MQ, the details of which can be found [here](https://github.com/IBM/charts/blob/master/stable/ibm-mqadvanced-server-dev/RELEASENOTES.md).
+This is due to a update in IBM MQ, the details of which can be found [here](https://github.com/merative/charts/blob/master/stable/ibm-mqadvanced-server-dev/RELEASENOTES.md).
 
 ## WebSphere Liberty
 

--- a/src/pages/monitoring/mq_queue_depth_events_monitoring.mdx
+++ b/src/pages/monitoring/mq_queue_depth_events_monitoring.mdx
@@ -20,7 +20,7 @@ With IBM MQ Prometheus monitor, a wide variety of statistics
 about that queue manager are published.
 
 The following information describes how to enable Prometheus monitoring agent that connects to an IBM MQ server.
-This monitor is based on the open-source project [MQ Metrics Sample](https://github.com/ibm-messaging/mq-metric-samples)
+This monitor is based on the open-source project [MQ Metrics Sample](https://github.com/merative-messaging/mq-metric-samples)
 which provides the monitor `mq_prometheus` to be compiled and the image `mq-metric-prometheus` to be built.
 
 Together, they will expose metrics about the following queue depth events
@@ -46,7 +46,7 @@ The following commands show how to build the MQ Metrics Pod which contains the m
 
 ```
 # Clone repository locally
-git clone https://github.com/ibm-messaging/mq-metric-samples.git
+git clone https://github.com/merative-messaging/mq-metric-samples.git
 
 # Build code and image
 cd mq-metric-samples/scripts

--- a/src/pages/monitoring/xmlserver-monitoring.mdx
+++ b/src/pages/monitoring/xmlserver-monitoring.mdx
@@ -16,7 +16,7 @@ and [Starting the XML server](https://www.ibm.com/docs/en/spm/8.0.1?topic=server
 ## Sample implementation
 
 The sample implementation is based on a proof-of-concept performed to illustrate the capability.
-Artifacts used for the proof-of-concept are provided as samples in the [GitHub repo](https://github.com/IBM/spm-kubernetes).
+Artifacts used for the proof-of-concept are provided as samples in the [GitHub repo](https://github.com/merative/spm-kubernetes).
 
 Notable decisions and limitations used in performing the proof-of-concept:
 
@@ -156,7 +156,7 @@ Exporter thread:
 
 ## Creating the Docker image for the sidecar container
 
-In support of building the sidecar Docker image the following files are included in the `dockerfiles/Liberty/xmlserver-metrics` folder of the [GitHub repo](https://github.com/IBM/spm-kubernetes):
+In support of building the sidecar Docker image the following files are included in the `dockerfiles/Liberty/xmlserver-metrics` folder of the [GitHub repo](https://github.com/merative/spm-kubernetes):
 
 * The `.Dockerfile` that builds the image: `XMLServer-metrics.Dockerfile`
 * The sample proof-of-concept implementation executable, `xmlserver_prometheus.jar`, and source, `xmlserver_prometheus-sources.jar`
@@ -259,7 +259,7 @@ Sample files are provided to define the sidecar and Prometheus configuration and
 
 For more information see the [Configuration Reference](/deployment/config-reference#xml-server).
 
-The following files are included in the [helm-charts/xmlserver/](https://github.com/IBM/spm-kubernetes/tree/main/helm-charts/xmlserver)
+The following files are included in the [helm-charts/xmlserver/](https://github.com/merative/spm-kubernetes/tree/main/helm-charts/xmlserver)
 folder of the GitHub repo for deploying the `xmlserver-metrics` sidecar container and configuring it for the XML server:
 
 * `./templates/deployment.yaml` - defines the `xmlserver-metrics` sidecar

--- a/src/pages/prereq/git.mdx
+++ b/src/pages/prereq/git.mdx
@@ -5,7 +5,7 @@ description: GitHub repo
 
 This runbook and its associated artifacts are provisioned through GitHub.
 
-Download the [spm-kubernetes](https://github.com/IBM/spm-kubernetes)
+Download the [spm-kubernetes](https://github.com/merative/spm-kubernetes)
 repository on your development system. Take the following steps:
 
 ## Install Git
@@ -17,7 +17,7 @@ Git is the distributed version control system on which GitHub is built. Usually 
 Clone the repository locally by using the following command:
 
 ```shell
-git clone https://github.com/IBM/spm-kubernetes
+git clone https://github.com/merative/spm-kubernetes
 ```
 
 The Git clone command creates a folder that is named `spm-kubernetes` in your current path. This folder is referred to by `$SPM_HOME` (or `$env:SPM_HOME` for Windows) for the remainder of this runbook. The `$SPM_HOME` folder contains three subfolders:

--- a/src/pages/prereq/prereq.mdx
+++ b/src/pages/prereq/prereq.mdx
@@ -123,7 +123,7 @@ The technologies listed are fixed version support only, unless stated otherwise.
 |`(5)` &#124; Only Linux-based containers are supported by IBM Cúram Social Program Management.|
 |`(6)` &#124; IBM Cúram Social Program Management does not support Docker containers hosted outside IBM Cloud Kubernetes Services.|
 |`(7)` &#124; IBM Cúram Social Program Management only supports Helm version 3.x for deploying IBM Cúram Social Program Management on IBM Cloud Kubernetes Services (IKS).|
-|`(8)` &#124; For SPM 7.0.10.0 there is still a hard requirement on an external identity provider (e.g. OpenLDAP) for elasticity. This code is no longer available in the latest version of the runbook. This can be found in the [September 2020 release](https://github.com/IBM/spm-kubernetes/releases/tag/20.9.0).|
+|`(8)` &#124; For SPM 7.0.10.0 there is still a hard requirement on an external identity provider (e.g. OpenLDAP) for elasticity. This code is no longer available in the latest version of the runbook. This can be found in the [September 2020 release](https://github.com/merative/spm-kubernetes/releases/tag/20.9.0).|
 |`(9)` &#124; Kubernetes releases a new version quarterly. When a new version is released `n-2` is deprecated, and `n-3` is unsupported. For more information please see [Kubernetes version information and update actions](https://cloud.ibm.com/docs/containers?topic=containers-cs_versions)|
 |`(10)` &#124; Docker is due to drop support for Docker 19.03 in July 2021. After this date Docker 19.03 is not supported by IBM Cúram Social Program Management.|
 |`(11)` &#124; Support for Docker 20.10 was introduced as part of the SPM@Kubernetes 21.2.0 release.|

--- a/src/pages/supporting-infrastructure/mq/mq-on-openshift.mdx
+++ b/src/pages/supporting-infrastructure/mq/mq-on-openshift.mdx
@@ -15,7 +15,7 @@ IBM MQ certified container is supported only from SPM Version 7.0.11 and later v
 
 <InlineNotification>
 
-**Note**: The IBM MQ charts found in the Runbook Github repository are sample charts based on the IBM MQ public charts published [here](https://github.com/IBM/charts/tree/master/stable/ibm-mqadvanced-server-dev).
+**Note**: The IBM MQ charts found in the Runbook Github repository are sample charts based on the IBM MQ public charts published [here](https://github.com/merative/charts/tree/master/stable/ibm-mqadvanced-server-dev).
 
 </InlineNotification>
 

--- a/src/pages/troubleshooting/must_gather.mdx
+++ b/src/pages/troubleshooting/must_gather.mdx
@@ -18,7 +18,7 @@ description: MustGather data for SPM
 ## Introduction
 
 The information laid out in this section details the information needed when raising a support case. Note that not all information detailed is necessary when
-raising an issue on [GitHub](https://github.com/IBM/spm-kubernetes/issues).
+raising an issue on [GitHub](https://github.com/merative/spm-kubernetes/issues).
 
 <InlineNotification>
 


### PR DESCRIPTION
This repository was moved from the github.com/IBM organization and as such any hard-coded references to the original GH pages site will need to be updated. This PR replaces all occurrences of `ibm.github.io` instances to `merative.github.io`