### PR TITLE
v81 Release December 2023

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 _book
 *.html
-
+.vscode/
 /ci.*
 *.lock
 *.tgz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file
 
+## v23.12.0
+
+### Breaking Change
+
+* The settings for `ibmjava8-sdk-ubi8-minimal` have been updated to use version `8.0.11.0` instead of the `latest` ([#150](https://github.com/merative/spm-kubernetes/issues/150))
+  * For more information please see RedHat Knowledge Base: [Changes to using latest tag with product multi-stream container image repositories](https://access.redhat.com/articles/4301321)
+
+### Changed
+
+* The following helm-charts have been updated to chart version `23.12.0`: `apps`, `batch`, `mqserver`, `spm`, `uawebapp`, `web`, `xmlserver`
+* DB2 password updated to plain text
+* The following helm-charts updates have been made:
+  * Enable Http Compression on spm/templates/ingress.yaml, enabling GZIP to increase performance of file transfers on ingress
+* Updated WebSphere Liberty version to include `23.0.0.9`
+* Clarification around build IBM® SDK, Java™ Technology Edition on Apple M1 architecture
+
 ## v23.9.0
 
 ### Fixed

--- a/dockerfiles/Liberty/Batch.Dockerfile
+++ b/dockerfiles/Liberty/Batch.Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 ###############################################################################
 
-ARG WLP_VERSION=23.0.0.6-full-java8-ibmjava-ubi
+ARG WLP_VERSION=23.0.0.9-full-java8-ibmjava-ubi
 ARG ANT_VERSION=1.10.6
 
 # Intermediate image: extract Ant

--- a/dockerfiles/Liberty/ClientEAR.Dockerfile
+++ b/dockerfiles/Liberty/ClientEAR.Dockerfile
@@ -17,7 +17,7 @@
 
 ARG EAR_NAME
 ARG SERVERCODE_IMAGE=servercode:latest
-ARG WLP_VERSION=23.0.0.6-full-java8-ibmjava-ubi
+ARG WLP_VERSION=23.0.0.9-full-java8-ibmjava-ubi
 
 # Explode EAR in a disposable environment
 FROM alpine AS ExplodedEAR

--- a/dockerfiles/Liberty/ServerEAR.Dockerfile
+++ b/dockerfiles/Liberty/ServerEAR.Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 ###############################################################################
 
-ARG WLP_VERSION=23.0.0.6-full-java8-ibmjava-ubi
+ARG WLP_VERSION=23.0.0.9-full-java8-ibmjava-ubi
 ARG MQ_ADAPTER_VERSION=9.2.4.0
 ARG MQ_RA_LICENSE
 ARG JMX_EXPORTER_URL=https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.14.0/jmx_prometheus_javaagent-0.14.0.jar

--- a/dockerfiles/Liberty/Utilities.Dockerfile
+++ b/dockerfiles/Liberty/Utilities.Dockerfile
@@ -18,7 +18,7 @@
 # If set, must end with a forward slash, e.g. "registry.connect.redhat.com/"
 ARG BASE_REGISTRY
 
-FROM ${BASE_REGISTRY}ibm/ibmjava8-sdk-ubi8-minimal:latest
+FROM ${BASE_REGISTRY}ibm/ibmjava8-sdk-ubi8-minimal:8.0.8.11
 
 USER root
 RUN rpm -e --nodeps tzdata \

--- a/dockerfiles/Liberty/XMLServer.Dockerfile
+++ b/dockerfiles/Liberty/XMLServer.Dockerfile
@@ -44,7 +44,7 @@ RUN unzip -qo /tmp/apache-ant.zip -d /opt/ \
     && chmod -c +x /opt/ibm/Curam/xmlserver/*.sh
 
 # Final image
-FROM ${BASE_REGISTRY}ibm/ibmjava8-sdk-ubi8-minimal:latest
+FROM ${BASE_REGISTRY}ibm/ibmjava8-sdk-ubi8-minimal:8.0.8.11
 
 EXPOSE 1800
 WORKDIR /opt/ibm/Curam/xmlserver

--- a/dockerfiles/Liberty/content/Bootstrap.properties
+++ b/dockerfiles/Liberty/content/Bootstrap.properties
@@ -34,7 +34,7 @@ curam.db.username=db2admin
 # Database password. Required for DB2 configurations.
 # Encrypt the plain-text password using 'build encrypt -Dpassword=<password>'
 # Below is the encryption for the default password ("db2admin")
-curam.db.password=5itAmT5UzH7wR6kvkYqkTw==
+curam.db.password=db2admin
 
 # A valid database type, one of: - DB2 - ORA
 curam.db.type=DB2

--- a/dockerfiles/Liberty/xmlserver-metrics/XMLServer-metrics.Dockerfile
+++ b/dockerfiles/Liberty/xmlserver-metrics/XMLServer-metrics.Dockerfile
@@ -21,7 +21,7 @@ ARG XMLSERVER_PROMETHEUS_JAR=xmlserver-metrics/xmlserver_prometheus.jar
 ARG BASE_REGISTRY
 
 # Final image
-FROM ${BASE_REGISTRY}ibm/ibmjava8-sdk-ubi8-minimal:latest
+FROM ${BASE_REGISTRY}ibm/ibmjava8-sdk-ubi8-minimal:8.0.8.11
 
 EXPOSE 8080
 WORKDIR /opt/ibm/Curam/xmlserver

--- a/helm-charts/apps/Chart.yaml
+++ b/helm-charts/apps/Chart.yaml
@@ -31,7 +31,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 23.9.0
+version: 23.12.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/batch/Chart.yaml
+++ b/helm-charts/batch/Chart.yaml
@@ -30,7 +30,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 23.9.0
+version: 23.12.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/mqserver/Chart.yaml
+++ b/helm-charts/mqserver/Chart.yaml
@@ -31,7 +31,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 23.9.0
+version: 23.12.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/spm/Chart.yaml
+++ b/helm-charts/spm/Chart.yaml
@@ -31,7 +31,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 23.9.0
+version: 23.12.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team
@@ -57,22 +57,22 @@ icon: https://avatars2.githubusercontent.com/u/1459110
 
 dependencies:
   - name: apps
-    version: "~23.9.0"
+    version: "~23.12.0"
     repository: "@local-development"
   - name: batch
-    version: "~23.9.0"
+    version: "~23.12.0"
     repository: "@local-development"
   - name: uawebapp
-    version: "~23.9.0"
+    version: "~23.12.0"
     repository: "@local-development"
   - name: web
-    version: "~23.9.0"
+    version: "~23.12.0"
     repository: "@local-development"
   - name: mqserver
-    version: "~23.9.0"
+    version: "~23.12.0"
     repository: "@local-development"
   - name: xmlserver
-    version: "~23.9.0"
+    version: "~23.12.0"
     repository: "@local-development"
   - name: ibm-sch
     repository: "@sch"

--- a/helm-charts/spm/templates/ingress.yaml
+++ b/helm-charts/spm/templates/ingress.yaml
@@ -34,6 +34,9 @@ metadata:
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/session-cookie-path: /
     nginx.ingress.kubernetes.io/proxy-read-timeout: "150"
+    nginx.ingress.kubernetes.io/server-snippet: |
+      gzip on;
+      gzip_types application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component text/html text/xml image/vnd.microsoft.icon;
   {{- with .Values.global.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/helm-charts/uawebapp/Chart.yaml
+++ b/helm-charts/uawebapp/Chart.yaml
@@ -31,7 +31,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 23.9.0
+version: 23.12.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/web/Chart.yaml
+++ b/helm-charts/web/Chart.yaml
@@ -31,7 +31,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 23.9.0
+version: 23.12.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/xmlserver/Chart.yaml
+++ b/helm-charts/xmlserver/Chart.yaml
@@ -31,7 +31,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 23.9.0
+version: 23.12.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spm-kubernetes",
-  "version": "23.9.0",
+  "version": "23.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "spm-kubernetes",
-      "version": "23.9.0",
+      "version": "23.12.0",
       "license": "Apache 2.0",
       "dependencies": {
         "@carbon/icons-react": "^11.21.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spm-kubernetes",
   "private": true,
-  "version": "23.9.0",
+  "version": "23.12.0",
   "license": "Apache 2.0",
   "scripts": {
     "dev": "gatsby develop -H 0.0.0.0",

--- a/src/pages/build-images/base_images.mdx
+++ b/src/pages/build-images/base_images.mdx
@@ -27,6 +27,13 @@ export DOCKER_BUILDKIT=0
 
 ## IBM® SDK, Java™ Technology Edition
 
+<InlineNotification kind="warning">
+
+IBM® SDK, Java™ Technology Edition does not build on the Apple M1 architecture.
+If you need to build on Apple M1 architecture for local development you are required have an active Red Hat Subscriptionto use the Red Hat Container Registry.
+
+</InlineNotification>
+
 * Clone repository and change into the working directory:
 
   ```shell
@@ -37,7 +44,7 @@ export DOCKER_BUILDKIT=0
 * Build image:
 
   ```shell
-  ./build.sh ibm/ibmjava8-sdk-ubi8-minimal:latest ../8/sdk/ubi-min
+  ./build.sh ibm/ibmjava8-sdk-ubi8-minimal:8.0.8.11 ../8/sdk/ubi-min
   ```
 
 ## S2I Core (required for Apache HTTP Server)

--- a/src/pages/build-images/setup_docker_context.mdx
+++ b/src/pages/build-images/setup_docker_context.mdx
@@ -299,7 +299,7 @@ docker run --rm \
     -u root \
     -e ANT_HOME=/tmp/ant \
     -e WLP_HOME=/opt/ibm/wlp \
-    ibmcom/websphere-liberty:23.0.0.6-full-java8-ibmjava-ubi \
+    ibmcom/websphere-liberty:23.0.0.9-full-java8-ibmjava-ubi \
     bash -c 'export PATH=$ANT_HOME/bin:$PATH:.; build.sh internal.update.crypto.jar'
 ```
 
@@ -320,7 +320,7 @@ docker run --rm `
     -u root `
     -e ANT_HOME=/tmp/ant `
     -e WLP_HOME=/opt/ibm/wlp `
-    ibmcom/websphere-liberty:23.0.0.6-full-java8-ibmjava-ubi `
+    ibmcom/websphere-liberty:23.0.0.9-full-java8-ibmjava-ubi `
     bash -c 'export PATH=$ANT_HOME/bin:$PATH:.; build.sh internal.update.crypto.jar'
 ```
 

--- a/src/pages/deployment/hc_deployment.mdx
+++ b/src/pages/deployment/hc_deployment.mdx
@@ -78,7 +78,7 @@ The respective license agreements can be reviewed by running the following comma
 
 ```shell
 # IBM WebSphere Liberty
-docker run --rm -e LICENSE=view ibmcom/websphere-liberty:23.0.0.6-full-java8-ibmjava-ubi
+docker run --rm -e LICENSE=view ibmcom/websphere-liberty:23.0.0.9-full-java8-ibmjava-ubi
 
 # IBM WebSphere MQ
 docker run --rm -e LICENSE=view ibmcom/mq:9.1.3.0

--- a/src/pages/prereq/3rdparty-sw.mdx
+++ b/src/pages/prereq/3rdparty-sw.mdx
@@ -37,7 +37,7 @@ If you are not an existing WebSphere customer, you can download a 60-day trial o
 
 ### Install IBM WebSphere Liberty
 
-WebSphere Liberty 23.0.0.6 is the only application server supported by SPM on Kubernetes and is therefore required.
+WebSphere Liberty 23.0.0.9 is the only application server supported by SPM on Kubernetes and is therefore required.
 
 #### Download and install WebSphere Liberty.
 

--- a/src/pages/prereq/prereq.mdx
+++ b/src/pages/prereq/prereq.mdx
@@ -49,8 +49,8 @@ The technologies listed are fixed version support only, unless stated otherwise.
 | Supported Software            | Version                   | Prerequisite Minimum  | Notes    |
 | ----------------------------- | ------------------------- | --------------------- | -------- |
 | Kubernetes ![AKS only](https://img.shields.io/badge/-AKS_only-blue)             | 1.25 and future releases      | 1.25                  | 1,2    |
-| OpenShift  ![OpenShift only](https://img.shields.io/badge/-OpenShift_only-red)  | 4.11                          | 4.11                  | 3,4    |
-| WebSphere Liberty                                                               | 23.0.0.3 and future fix packs | 22.0.0.9              | 5      |
+| OpenShift  ![OpenShift only](https://img.shields.io/badge/-OpenShift_only-red)  | 4.12                          | 4.11                  | 3,4    |
+| WebSphere Liberty                                                               | 23.0.0.9 and future fix packs | 22.0.0.9              | 5      |
 | IBM MQ LTS                                                                      | 9.2 and future fix packs      | 9.2.0.2               | 6      |
 | IBM MQ CD ![OpenShift only](https://img.shields.io/badge/-OpenShift_only-red)   | 9.2 and future fix packs      | 9.2.2.0               | 7      |
 | Docker                                                                          | 24                            | 24.0.2                | 8,9,10 |
@@ -77,7 +77,7 @@ The technologies listed are fixed version support only, unless stated otherwise.
 
 | Supported Software                                                              | Version                             | Prerequisite Minimum  | Notes       |
 | ------------------------------------------------------------------------------- | ----------------------------------- | --------------------- | ------------|
-| WebSphere Liberty                                                               | 23.0.0.6 and future fix packs       | 21.0.0.6              | 1           |
+| WebSphere Liberty                                                               | 23.0.0.9 and future fix packs       | 21.0.0.12             | 1           |
 | OpenShift ![OpenShift only](https://img.shields.io/badge/-OpenShift_only-red)   | 4.6 and future releases             | 4.6 <br/> 4.6 EUS     | 2,4,5         |
 | IBM MQ LTS                                                                      | 9.2 and future fix packs<br/> 9.1 and future fix packs | 9.2.0.2  <br/> 9.1.0.5 | 6           |
 | IBM MQ CD ![OpenShift only](https://img.shields.io/badge/-OpenShift_only-red)   | 9.2 and future fix packs            | 9.2.2.0               | 7           |

--- a/src/pages/supporting-infrastructure/mq/mq-on-openshift.mdx
+++ b/src/pages/supporting-infrastructure/mq/mq-on-openshift.mdx
@@ -6,9 +6,6 @@ tabs: ['MQ Overview','MQ on AKS', 'MQ on OpenShift','MQ Containers']
 
 ## Support for IBM MQ certified containers on OpenShift
 
-Merative Social Program Management (SPM) customers may obtain IBM MQ certified containers from the IBM Cloud Container Registry for use as a Supporting Program for SPM.
-Use as a Supporting Program means that IBM MQ certified containers can only be used to process internal JMS messages within SPM.
-
 SPM does not require or support the use of any IBM MQ Advanced features available in the IBM MQ certified containers.
 
 IBM MQ certified container is supported only from SPM Version 7.0.11 and later versions.


### PR DESCRIPTION
## v23.12.0

### Breaking Change

* The settings for `ibmjava8-sdk-ubi8-minimal` have been updated to use version `8.0.11.0` instead of the `latest` ([#150](https://github.com/merative/spm-kubernetes/issues/150))
  * For more information please see RedHat Knowledge Base: [Changes to using latest tag with product multi-stream container image repositories](https://access.redhat.com/articles/4301321)

### Changed

* The following helm-charts have been updated to chart version `23.12.0`: `apps`, `batch`, `mqserver`, `spm`, `uawebapp`, `web`, `xmlserver`
* DB2 password updated to plain text
* The following helm-charts updates have been made:
  * Enable Http Compression on spm/templates/ingress.yaml, enabling GZIP to increase performance of file transfers on ingress
* Updated WebSphere Liberty version to include `23.0.0.9`
* Clarification around build IBM® SDK, Java™ Technology Edition on Apple M1 architecture