### PR TITLE
v8.1.2.0_iFix2b Release November 2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ All notable changes to this project will be documented in this file
 ### Breaking Change
 
 * To enable persistence and the capturing of metrics on the batch pods Batch.Dockerfile has been updated with the following
-  * The Batch.Dockerfile was updated to pull `jmx_prometheus_javaagent-0.14.0.jar` from `repo1.maven.org`
   * The Batch.Dockerfile was updated to copy `docker-server.sh` to allow scripts for persistence
   * Updated `helm-charts/batch/templates/cronjob-program.yaml` command and args to run `docker-server.sh` not updating charts for this Batch.Dockerfile will cause charts to fail
   * Helm charts updated kubeVersion from `">=1.20"` to `">=1.20 || >=1.30.0-eks-a737599"`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this project will be documented in this file
 
+## v24.11.0
+
+### Breaking Change
+
+* To enable persistence and the capturing of metrics on the batch pods Batch.Dockerfile has been updated with the following
+  * The Batch.Dockerfile was updated to pull `jmx_prometheus_javaagent-0.14.0.jar` from `repo1.maven.org`
+  * The Batch.Dockerfile was updated to copy `docker-server.sh` to allow scripts for persistence
+  * Updated `helm-charts/batch/templates/cronjob-program.yaml` command and args to run `docker-server.sh` not updating charts for this Batch.Dockerfile will cause charts to fail
+  * Helm charts updated kubeVersion from `">=1.20"` to `">=1.20 || >=1.30.0-eks-a737599"`
+
+### Added
+
+* Create `helm-charts/batch/templates/configmaps/configmap-jmx-batch-config.yaml` for JMX Exporter
+* Update `config-reference` to allow `batch.jmxExporter.enabled` and `batch.jmxExporter.port` to be configured
+* Support for future releases of OpenShift
+
+### Changed
+
+* Updated `helm-charts/batch/templates/cronjob-program.yaml` to allow batch launcher logs be persistent
+* Updated `helm-charts/batch/templates/_helpers.tpl` for persistence
+* Updated `helm-charts/batch/templates/cronjob-program.yaml` to allow JMX Exporting and persistence
+* Updated `helm-charts/batch/values.yaml` for JMX Exporter
+* Updated `batch` yaml for copyright changes
+* The following helm-charts have been updated to chart version `24.11.0`: `apps`, `batch`, `mqserver`, `spm`, `uawebapp`, `web`, `xmlserver`
+* Updated WebSphere Liberty version to include `24.0.0.6`
+* Updated batch helm chart to read Java max memory from values file
+* `ibmjava8-sdk-ubi8-minimal` updated to `8.0.30.0`
+
 ## v24.2.0
 
 ### Changed

--- a/dockerfiles/Liberty/Batch.Dockerfile
+++ b/dockerfiles/Liberty/Batch.Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# © Merative US L.P. 2022
+# © Merative US L.P. 2024
 # Copyright 2020 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,8 +15,9 @@
 # limitations under the License.
 ###############################################################################
 
-ARG WLP_VERSION=23.0.0.12-full-java8-ibmjava-ubi
+ARG WLP_VERSION=24.0.0.6-full-java8-ibmjava-ubi
 ARG ANT_VERSION=1.10.6
+ARG JMX_EXPORTER_URL=https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.14.0/jmx_prometheus_javaagent-0.14.0.jar
 
 # Intermediate image: extract Ant
 FROM alpine AS PrepStage
@@ -49,8 +50,12 @@ RUN rpm -e --nodeps tzdata \
     && yum install -y tzdata \
     && yum clean all \
     && rm -rf /var/cache/yum
+ARG JMX_EXPORTER_URL
+ADD $JMX_EXPORTER_URL /opt/ibm/Curam/jmx_prometheus_javaagent.jar
+RUN chmod -c +rx /opt/ibm/Curam/jmx_prometheus_javaagent.jar
 USER 1001
 
+COPY --chown=1001:0 content/*.sh /opt/ibm/helpers/runtime/
 COPY --from=PrepStage --chown=1001:0 /opt/apache-ant-${ANT_VERSION} /opt/apache-ant-${ANT_VERSION}
 COPY --from=PrepStage --chown=1001:0 /opt/javamail /opt/javamail
 COPY --from=PrepStage --chown=1001:0 /opt/ibm/Curam /opt/ibm/Curam

--- a/dockerfiles/Liberty/ClientEAR.Dockerfile
+++ b/dockerfiles/Liberty/ClientEAR.Dockerfile
@@ -17,7 +17,7 @@
 
 ARG EAR_NAME
 ARG SERVERCODE_IMAGE=servercode:latest
-ARG WLP_VERSION=23.0.0.12-full-java8-ibmjava-ubi
+ARG WLP_VERSION=24.0.0.6-full-java8-ibmjava-ubi
 
 # Explode EAR in a disposable environment
 FROM alpine AS ExplodedEAR

--- a/dockerfiles/Liberty/ServerEAR.Dockerfile
+++ b/dockerfiles/Liberty/ServerEAR.Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# © Merative US L.P. 2022
+# © Merative US L.P. 2024
 # Copyright 2020,2022 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,7 @@
 # limitations under the License.
 ###############################################################################
 
-ARG WLP_VERSION=23.0.0.12-full-java8-ibmjava-ubi
+ARG WLP_VERSION=24.0.0.6-full-java8-ibmjava-ubi
 ARG MQ_ADAPTER_VERSION=9.2.4.0
 ARG MQ_RA_LICENSE
 ARG JMX_EXPORTER_URL=https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.14.0/jmx_prometheus_javaagent-0.14.0.jar
@@ -74,5 +74,6 @@ COPY --chown=1001:0 content/release-stage/build/CryptoConfig.jar /opt/ibm/java/j
 COPY --from=ExplodedEAR --chown=1001:0 /work /config/apps
 COPY --from=ExplodedEAR --chown=1001:0 /tmp/properties.jar /shared_resources/
 
+# Install defaultServer and wmqJmsClient-2.0 if available
 RUN installUtility install defaultServer \
     && (installUtility install wmqJmsClient-2.0 || true)

--- a/dockerfiles/Liberty/XMLServer.Dockerfile
+++ b/dockerfiles/Liberty/XMLServer.Dockerfile
@@ -44,7 +44,7 @@ RUN unzip -qo /tmp/apache-ant.zip -d /opt/ \
     && chmod -c +x /opt/ibm/Curam/xmlserver/*.sh
 
 # Final image
-FROM ${BASE_REGISTRY}ibm/ibmjava8-sdk-ubi8-minimal:8.0.8.11
+FROM ${BASE_REGISTRY}ibm/ibmjava8-sdk-ubi8-minimal:8.0.8.30
 
 EXPOSE 1800
 WORKDIR /opt/ibm/Curam/xmlserver

--- a/dockerfiles/Liberty/xmlserver-metrics/XMLServer-metrics.Dockerfile
+++ b/dockerfiles/Liberty/xmlserver-metrics/XMLServer-metrics.Dockerfile
@@ -21,7 +21,7 @@ ARG XMLSERVER_PROMETHEUS_JAR=xmlserver-metrics/xmlserver_prometheus.jar
 ARG BASE_REGISTRY
 
 # Final image
-FROM ${BASE_REGISTRY}ibm/ibmjava8-sdk-ubi8-minimal:8.0.8.11
+FROM ${BASE_REGISTRY}ibm/ibmjava8-sdk-ubi8-minimal:8.0.8.30
 
 EXPOSE 8080
 WORKDIR /opt/ibm/Curam/xmlserver

--- a/helm-charts/apps/Chart.yaml
+++ b/helm-charts/apps/Chart.yaml
@@ -16,7 +16,7 @@
 ###############################################################################
 
 apiVersion: v2
-kubeVersion: ">=1.20"
+kubeVersion: ">=1.20 || >=1.30.0-eks-a737599"
 appVersion: "8.1.0.0"
 name: apps
 description: |-
@@ -31,7 +31,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 24.2.0
+version: 24.11.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/batch/Chart.yaml
+++ b/helm-charts/batch/Chart.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 ###############################################################################
 apiVersion: v2
-kubeVersion: ">=1.20"
+kubeVersion: ">=1.20 || >=1.30.0-eks-a737599"
 appVersion: "8.1.0.0"
 name: batch
 description: |-
@@ -30,7 +30,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 24.2.0
+version: 24.11.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/batch/templates/configmaps/configmap-jmx-batch-config.yaml
+++ b/helm-charts/batch/templates/configmaps/configmap-jmx-batch-config.yaml
@@ -1,6 +1,8 @@
+{{- include "sch.config.init" (list . "batch.sch.chart.config.values") -}}
+{{- if .Values.jmxExporter.enabled }}
+---
 ###############################################################################
-# © Merative US L.P. 2022
-# Copyright 2020 IBM Corporation
+# © Merative US L.P. 2024
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,15 +17,14 @@
 # limitations under the License.
 ###############################################################################
 
-# If set, must end with a forward slash, e.g. "registry.connect.redhat.com/"
-ARG BASE_REGISTRY
-
-FROM ${BASE_REGISTRY}ibm/ibmjava8-sdk-ubi8-minimal:8.0.8.30
-
-USER root
-RUN rpm -e --nodeps tzdata \
-    && microdnf install -y nc tzdata \
-    && microdnf clean all \
-    && rm -rf /var/cache/yum
-
-USER 1001
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-jmx-batch-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sch.metadata.labels.standard" (list . "") | nindent 4 }}
+data:
+  config.yaml: |-
+    {{- .Values.jmxExporter.configYaml | default "" | nindent 4 -}}
+{{- end }}

--- a/helm-charts/batch/templates/cronjob-program.yaml
+++ b/helm-charts/batch/templates/cronjob-program.yaml
@@ -1,10 +1,10 @@
 {{- include "sch.config.init" (list . "batch.sch.chart.config.values") -}}
 {{- range $name, $program := .Values.programs }}
 {{- $filtered_name := ( $name | replace "_" "-" ) }}
-{{- $javaOptions := dict "DefaultOptions" $.Values.javaOptions "ProgramOptions" $program.javaOptions "PersistenceConfig" $.Values.global.apps.common.persistence }}
+{{- $javaOptions := dict "DefaultOptions" $.Values.javaOptions "MaxMemory" $.Values.maxMemory "ProgramOptions" $program.javaOptions "PersistenceConfig" $.Values.global.apps.common.persistence }}
 ---
 ###############################################################################
-# © Merative US L.P. 2022
+# © Merative US L.P. 2022,2024
 # Copyright 2019,2020 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,12 +53,22 @@ spec:
             - name: bootstrap-file
               configMap:
                 name: {{ $.Release.Name }}-bootstrap-cm
-          {{- if and (eq ($.Values.global.database.type | upper) "DB2") $.Values.global.database.ssl.enabled $.Values.global.database.ssl.secretName }}
+            {{- if $.Values.jmxExporter.enabled }}
+            - name: jmx-batch-config
+              configMap:
+                name: {{ $.Release.Name }}-jmx-batch-config
+            {{- end }}
+            {{- if and (eq ($.Values.global.database.type | upper) "DB2") $.Values.global.database.ssl.enabled $.Values.global.database.ssl.secretName }}
             - name: keystore-volume
               emptyDir: {}
             - name: db2-cert
               secret:
                 secretName: {{ $.Values.global.database.ssl.secretName }}
+            {{- if $.Values.global.apps.common.persistence.enabled }}
+            - name: {{ $.Release.Name }}-persistence-volume
+              persistentVolumeClaim:
+                claimName: {{ $.Release.Name }}-persistence-pvc
+            {{- end }}
           initContainers:
           - name: import-db2-cert
             image: {{ include "batch.imageFullName" (dict "ImageConfig" $.Values.global.images "ImageName" "utilities") }}
@@ -70,7 +80,7 @@ spec:
             command:
               - /bin/sh
               - -c
-              - keytool -import -trustcacerts -noprompt -file $certfile -keystore $keystore_jks -storepass changeit -storetype jks
+              - keytool -import -trustcacerts -noprompt -file $certfile -keystore $keystore_jks -storepass changeit -storetype jks  
             volumeMounts:
             - name: keystore-volume
               mountPath: /mnt/keystores
@@ -81,6 +91,11 @@ spec:
           - name: runbatch-{{ $filtered_name | lower }}
             image: {{ include "batch.imageFullName" (dict "ImageConfig" $.Values.global.images "ImageName" "batch") }}
             imagePullPolicy: {{ $.Values.global.images.pullPolicy }}
+            {{- if $.Values.jmxExporter.enabled }}
+            ports:
+              - name: jmxmetrics
+                containerPort: {{ $.Values.jmxExporter.port }}
+            {{- end }}
             envFrom:
               - secretRef:
                   name: {{ default (printf "%s-db-credentials" $.Release.Name) $.Values.global.database.credsSecretName }}
@@ -89,11 +104,15 @@ spec:
                 value: {{ include "batch.antOpts" $javaOptions | quote }}
               - name: TZ
                 value: {{ $.Values.global.timezone }}
-            command:
-              - /opt/ibm/Curam/release/build.sh
-              - runbatch
-            {{- if or $program.className $program.parameters $program.username }}
+              {{- if $.Values.global.apps.common.persistence.enabled }}
+              - name: MOUNT_POINT
+                value: {{ include "persistence.mountPoint" $ }}
+              {{- end }}
+            command: ["/bin/sh", "-c"]
             args:
+            - /opt/ibm/helpers/runtime/docker-server.sh && 
+              /opt/ibm/Curam/release/build.sh runbatch{{ if $.Values.global.apps.common.persistence.enabled }} -Ddir.bld.log=$MOUNT_POINT/$HOSTNAME/logs{{ end }}
+            {{- if or $program.className $program.parameters $program.username }}
             {{- if $program.className }}
               - -Dbatch.program={{ $program.className }}
             {{- end }}
@@ -116,6 +135,15 @@ spec:
               {{- if and (eq ($.Values.global.database.type | upper) "DB2") $.Values.global.database.ssl.enabled $.Values.global.database.ssl.secretName }}
               - name: keystore-volume
                 mountPath: /mnt/keystores
+              {{- end }}
+              {{- if $.Values.jmxExporter.enabled }}
+              - name: jmx-batch-config
+                mountPath: /config/configDropins/overrides/config.yaml
+                subPath: config.yaml
+              {{- end }}
+              {{- if $.Values.global.apps.common.persistence.enabled }}
+              - name: {{ $.Release.Name }}-persistence-volume
+                mountPath: {{ include "persistence.mountPoint" $ }}
               {{- end }}
           restartPolicy: Never
 {{- end }}

--- a/helm-charts/batch/values.yaml
+++ b/helm-charts/batch/values.yaml
@@ -1,5 +1,5 @@
 ###############################################################################
-# © Merative US L.P. 2022,2023
+# © Merative US L.P. 2022,2023,2024
 # Copyright 2019,2020 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -77,7 +77,10 @@ global:
 serviceAccountName: ""
 
 # Default Java Options for batch jobs
-javaOptions: '-Xms1g -Xmx1g'
+javaOptions: ' -Xms728m -Xmx728m'
+
+# Default Max JVM memmory 
+maxMemory: '1024m'
 
 # Resource limits for Batch jobs (can be overridden per job)
 resources:
@@ -135,3 +138,8 @@ streamed: {}
 # weight 100 for nodes labelled as worker-type:application
 affinityKey: worker-type
 affinityValue: application
+# JMX Exporter configuration (Beta Feature)
+jmxExporter:
+  enabled: false
+  port: 8080
+  configYaml: ''

--- a/helm-charts/mqserver/Chart.yaml
+++ b/helm-charts/mqserver/Chart.yaml
@@ -16,7 +16,7 @@
 ###############################################################################
 
 apiVersion: v2
-kubeVersion: ">=1.20"
+kubeVersion: ">=1.20 || >=1.30.0-eks-a737599"
 appVersion: "8.1.0.0"
 name: mqserver
 description: |-
@@ -31,7 +31,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 24.2.0
+version: 24.11.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/spm/Chart.yaml
+++ b/helm-charts/spm/Chart.yaml
@@ -16,7 +16,7 @@
 ###############################################################################
 
 apiVersion: v2
-kubeVersion: ">=1.20"
+kubeVersion: ">=1.20 || >=1.30.0-eks-a737599"
 appVersion: "8.1.0.0"
 name: spm
 description: |-
@@ -31,7 +31,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 24.2.0
+version: 24.11.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team
@@ -57,22 +57,22 @@ icon: https://avatars2.githubusercontent.com/u/1459110
 
 dependencies:
   - name: apps
-    version: "~24.2.0"
+    version: "~24.11.0"
     repository: "@local-development"
   - name: batch
-    version: "~24.2.0"
+    version: "~24.11.0"
     repository: "@local-development"
   - name: uawebapp
-    version: "~24.2.0"
+    version: "~24.11.0"
     repository: "@local-development"
   - name: web
-    version: "~24.2.0"
+    version: "~24.11.0"
     repository: "@local-development"
   - name: mqserver
-    version: "~24.2.0"
+    version: "~24.11.0"
     repository: "@local-development"
   - name: xmlserver
-    version: "~24.2.0"
+    version: "~24.11.0"
     repository: "@local-development"
   - name: ibm-sch
     repository: "@sch"

--- a/helm-charts/uawebapp/Chart.yaml
+++ b/helm-charts/uawebapp/Chart.yaml
@@ -16,7 +16,7 @@
 ###############################################################################
 
 apiVersion: v2
-kubeVersion: ">=1.20"
+kubeVersion: ">=1.20 || >=1.30.0-eks-a737599"
 appVersion: "8.1.0.0"
 name: uawebapp
 description: |-
@@ -31,7 +31,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 24.2.0
+version: 24.11.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/web/Chart.yaml
+++ b/helm-charts/web/Chart.yaml
@@ -16,7 +16,7 @@
 ###############################################################################
 
 apiVersion: v2
-kubeVersion: ">=1.20"
+kubeVersion: ">=1.20 || >=1.30.0-eks-a737599"
 appVersion: "8.1.0.0"
 name: web
 description: |-
@@ -31,7 +31,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 24.2.0
+version: 24.11.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/xmlserver/Chart.yaml
+++ b/helm-charts/xmlserver/Chart.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 ###############################################################################
 apiVersion: v2
-kubeVersion: ">=1.20"
+kubeVersion: ">=1.20 || >=1.30.0-eks-a737599"
 appVersion: "8.1.0.0"
 name: xmlserver
 description: |-
@@ -31,7 +31,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 24.2.0
+version: 24.11.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spm-kubernetes",
-  "version": "24.2.0",
+  "version": "24.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "spm-kubernetes",
-      "version": "24.2.0",
+      "version": "24.11.0",
       "license": "Apache 2.0",
       "dependencies": {
         "@carbon/icons-react": "^11.36.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spm-kubernetes",
   "private": true,
-  "version": "24.2.0",
+  "version": "24.11.0",
   "license": "Apache 2.0",
   "scripts": {
     "dev": "gatsby develop -H 0.0.0.0",
@@ -14,13 +14,13 @@
     "serve:prefix": "gatsby serve --prefix-paths"
   },
   "dependencies": {
-    "@carbon/icons-react": "^11.36.0",
+    "@carbon/icons-react": "^11.51.0",
     "carbon-components": "^10.58.12",
     "carbon-components-react": "^8.51.0",
     "gatsby": "^4.25.8",
     "gatsby-cli": "4.25.0",
-    "gatsby-theme-carbon": "^3.4.13",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "gatsby-theme-carbon": "^3.4.21",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   }
 }

--- a/src/pages/build-images/base_images.mdx
+++ b/src/pages/build-images/base_images.mdx
@@ -44,7 +44,7 @@ If you need to build on Apple M1 architecture for local development you are requ
 * Build image:
 
   ```shell
-  ./build.sh ibm/ibmjava8-sdk-ubi8-minimal:8.0.8.11 ../8/sdk/ubi-min
+  ./build.sh ibm/ibmjava8-sdk-ubi8-minimal:8.0.8.30 ../8/sdk/ubi-min
   ```
 
 ## S2I Core (required for Apache HTTP Server)

--- a/src/pages/build-images/setup_docker_context.mdx
+++ b/src/pages/build-images/setup_docker_context.mdx
@@ -299,7 +299,7 @@ docker run --rm \
     -u root \
     -e ANT_HOME=/tmp/ant \
     -e WLP_HOME=/opt/ibm/wlp \
-    ibmcom/websphere-liberty:23.0.0.12-full-java8-ibmjava-ubi \
+    ibmcom/websphere-liberty:24.0.0.6-full-java8-ibmjava-ubi \
     bash -c 'export PATH=$ANT_HOME/bin:$PATH:.; build.sh internal.update.crypto.jar'
 ```
 
@@ -320,7 +320,7 @@ docker run --rm `
     -u root `
     -e ANT_HOME=/tmp/ant `
     -e WLP_HOME=/opt/ibm/wlp `
-    ibmcom/websphere-liberty:23.0.0.12-full-java8-ibmjava-ubi `
+    ibmcom/websphere-liberty:24.0.0.6-full-java8-ibmjava-ubi `
     bash -c 'export PATH=$ANT_HOME/bin:$PATH:.; build.sh internal.update.crypto.jar'
 ```
 

--- a/src/pages/deployment/config-reference.mdx
+++ b/src/pages/deployment/config-reference.mdx
@@ -127,6 +127,8 @@ In the following properties, `<progID>` is a placeholder for the name of the bat
 | `batch.backoffLimit` | Number of retries for failed Batch executions | `1` |
 | `batch.javaOptions` | Default Java Heap options for all programs | `-Xms1g -Xmx1g` |
 | `batch.successfulJobsHistoryLimit` | Number of successful batch executions to keep | `3` |
+| `batch.jmxExporter.enabled`| Enable the Prometheus JMX Exporter for the Batch server metrics | `false` |
+| `batch.jmxExporter.port`| The port to monitor the XML server JVM metrics | `8080` |
 | --------- | ----------- | ------- |
 | `batch.programs.<progID>.activeDeadlineSeconds` | Number of seconds within which the job is expected to complete. If this time is exceeded, the job is terminated. Blank value denoted no limit. | `''` |
 | `batch.programs.<progID>.className` | Java class for the batch process (`-Dbatch.program=`) | `''` |

--- a/src/pages/deployment/hc_deployment.mdx
+++ b/src/pages/deployment/hc_deployment.mdx
@@ -78,7 +78,7 @@ The respective license agreements can be reviewed by running the following comma
 
 ```shell
 # IBM WebSphere Liberty
-docker run --rm -e LICENSE=view ibmcom/websphere-liberty:23.0.0.12-full-java8-ibmjava-ubi
+docker run --rm -e LICENSE=view ibmcom/websphere-liberty:24.0.0.6-full-java8-ibmjava-ubi
 
 # IBM WebSphere MQ
 docker run --rm -e LICENSE=view ibmcom/mq:9.1.3.0

--- a/src/pages/prereq/3rdparty-sw.mdx
+++ b/src/pages/prereq/3rdparty-sw.mdx
@@ -32,8 +32,8 @@ After installing WebSphere Liberty you will need to apply a fix pack using Insta
 
 ### IBM WebSphere Liberty licensing
 
-If you are an existing WebSphere customer, you are entitled to access a WebSphere Liberty license.
-If you are not an existing WebSphere customer, you can download a 60-day trial of WebSphere Liberty. For more information, see [IBM WebSphere Liberty: Pricing](https://www.ibm.com/cloud/websphere-liberty/pricing).
+Customers who are licensed for WebSphere Hybrid Edition or IBM Cloudpak for Applications are entitled to access a WebSphere liberty licence.
+However, we advise clients to seek licence advice from their IBM re-seller regarding entitlements. If you are not an existing WebSphere customer you can download a 60 day trial of WebsShere Liberty from IBM.
 
 ### Install IBM WebSphere Liberty
 
@@ -62,18 +62,6 @@ WLP_HOME=/opt/IBM/WebSphere/Liberty
 ```
 
 ## Java
-
-<InlineNotification kind="info">
-
-**Java Vendor**:
-
-The runbook suggests the use of IBM SDK Java. However IBM's SDK is not available on MacOS.
-
-If you are following this runbook on a developer Mac, we suggest you use [Oracle SDK  Java](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html)
-instead. All steps will be the same apart from the SDK installation procedure.
-You should still set up the environment variables as described in this section.
-
-</InlineNotification>
 
 Java version 8 is required. See
 [IBM SDK Java Technology Edition Version 8.0](https://www.ibm.com/support/pages/java-sdk-downloads-version-80)

--- a/src/pages/prereq/prereq.mdx
+++ b/src/pages/prereq/prereq.mdx
@@ -41,8 +41,38 @@ The technologies listed are fixed version support only, unless stated otherwise.
 </InlineNotification>
 
 <Accordion>
+<AccordionItem title="SPM 8.1.2.0"  open='true'>
 
-<AccordionItem title="SPM 8.1.0.0"  open='true'>
+<InlineNotification kind="warning">Azure Kubernetes Services (AKS) is exclusively available for Development and Test purposes **only**.</InlineNotification>
+
+| Supported Software            | Version                   | Prerequisite Minimum  | Notes    |
+| ----------------------------- | ------------------------- | --------------------- | -------- |
+| Kubernetes ![AKS only](https://img.shields.io/badge/-AKS_only-blue)             | 1.29 and future releases      | 1.29                  | 1,2    |
+| OpenShift  ![OpenShift only](https://img.shields.io/badge/-OpenShift_only-red)  | 4.13 and future releases      | 4.13                  | 3,4    |
+| WebSphere Liberty                                                               | 24.0.0.6 and future fix packs | 22.0.0.9              | 5      |
+| IBM MQ LTS                                                                      | 9.2 and future fix packs      | 9.2.0.2               | 6      |
+| IBM MQ CD ![OpenShift only](https://img.shields.io/badge/-OpenShift_only-red)   | 9.2 and future fix packs      | 9.2.2.0               | 7      |
+| Docker                                                                          | 24                            | 24.0.2                | 8,9,10 |
+| Helm                                                                            | v3 and future releases        | v3.3.4                | 11,12  |
+
+|Notes|
+|-|
+|`(1)` &#124; Merative Social Program Management only supports Azure Kubernetes Services (AKS) distribution of Kubernetes, for Development and Test purposes **only**.|
+|`(2)` &#124; Kubernetes releases a new version quarterly. When a new version is released `n-2` is deprecated, and `n-3` is unsupported. For more information please see [Supported Kubernetes versions in Azure Kubernetes Service (AKS)](https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar)|
+|`(3)` &#124; OpenShift releases a new version quarterly. When a new version is released `n-1` and `n-2` is in  *Maintenance Support*, and `n-3` is *unsupported*. For more information please see [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)|
+|`(4)` Merative Social Program Management supports Red Hat OpenShift Extended Update Support (EUS). For more information please see [Red Hat OpenShift Extended Update Support (EUS) Overview](https://access.redhat.com/support/policy/updates/openshift-eus).|
+|`(5)` &#124; Merative Social Program Management only supports IBM WebSphere Liberty when containerized as Docker containers and deployed on Kubernetes Services. |
+|`(6)` &#124; Merative Social Program Management only supports IBM MQ Long Term Support (LTS) when Merative Social Program Management is containerized and deployed on Azure Kubernetes Services (AKS).|
+|`(7)` &#124; Merative Social Program Management only supports IBM MQ CD when Merative Social Program Management is containerized and deployed on OpenShift only.|
+|`(8)` &#124; Merative Social Program Management only supports Docker for packaging Merative Social Program Management into containers for deployment on Azure Kubernetes Services (AKS).|
+|`(9)` &#124; Only Linux-based containers are supported by Merative Social Program Management.|
+|`(10)` &#124; Merative Social Program Management does not support Docker containers hosted outside Azure Kubernetes Services.|
+|`(11)` &#124; Merative Social Program Management only supports Helm version 3.x for deploying Merative Social Program Management on Azure Kubernetes Services (AKS). or OpenShift|
+|`(12)` &#124; From Helm release `v3.7.0`, the ChartMuseum Push plugin to be used with Merative Social Program Management must be version `0.10.0` or greater|
+
+</AccordionItem>
+
+<AccordionItem title="SPM 8.1.0.0">
 
 <InlineNotification kind="warning">Azure Kubernetes Services (AKS) is exclusively available for Development and Test purposes **only**.</InlineNotification>
 
@@ -98,34 +128,6 @@ The technologies listed are fixed version support only, unless stated otherwise.
 |`(11)` &#124; Merative Social Program Management *only requires* Docker to build container images, Merative Social Program Management *does not require* Docker as a container runtime engine.|
 |`(12))` &#124; Merative Social Program Management only supports Helm version 3.x for deploying Merative Social Program Management on OpenShift.|
 |`(13)` &#124; From Helm release `v3.7.0`, the ChartMuseum Push plugin to be used with Merative Social Program Management must be version `0.10.0` or greater|
-</AccordionItem>
-
-<AccordionItem title="SPM 7.0.11.0">
-
-| Supported Software                                                              | Version                             | Prerequisite Minimum  | Notes       |
-| ------------------------------------------------------------------------------- | ----------------------------------- | --------------------- | ------------|
-| WebSphere Liberty                                                               | 22.0.0.6, 21.0.0.9, 20.0.0.9        | 20.0.0.9              | 1           |
-| OpenShift ![OpenShift only](https://img.shields.io/badge/-OpenShift_only-red)   | 4.6 and future releases             | 4.6 <br/> 4.6 EUS     | 12          |
-| IBM MQ LTS                                                                      | 9.1 and future fix packs            | 9.1.0.5               | 3           |
-| IBM MQ CD ![OpenShift only](https://img.shields.io/badge/-OpenShift_only-red)   | 9.1 and future fix packs            | 9.1.5.0               | 8           |
-| Docker                                                                          | 19.03                               | 19.03.5               | 4,5,6,9,13  |
-| Docker                                                                          | 20.10                               | 20.10.2               | 4,5,6,10,13 |
-| Helm                                                                            | v3 and future releases              | v3.3.4                | 7,14        |
-
-|Notes|
-|-|
-|`(1)` &#124; Merative Social Program Management only supports IBM WebSphere Liberty when containerized as Docker containers and deployed on OpenShift. |
-|`(3)` &#124; Merative Social Program Management only supports IBM MQ Long Term Support (LTS) when Merative Social Program Management is containerized and deployed on OpenShift.|
-|`(4)` &#124; Merative Social Program Management only supports Docker for packaging Merative Social Program Management into containers for deployment on OpenShift.|
-|`(5)` &#124; Only Linux-based containers are supported by Merative Social Program Management.|
-|`(6)` &#124; Merative Social Program Management does not support Docker containers hosted outside of OpenShift.|
-|`(7)` &#124; Merative Social Program Management only supports Helm version 3.x for deploying Merative Social Program Management on IBM Cloud Kubernetes Services (IKS), or OpenShift.|
-|`(8)` &#124; Merative Social Program Management only supports IBM MQ CD when Merative Social Program Management is containerized and deployed on OpenShift only.|
-|`(9)` &#124; Docker is due to drop support for Docker 19.03 in July 2021. After this date Docker 19.03 is not supported by Merative Social Program Management.|
-|`(10)` &#124; Support for Docker 20.10 was introduced as part of the SPM@Kubernetes 21.2.0 release.|
-|`(12)` &#124; OpenShift releases a new version quarterly. When a new version is released `n-1` and `n-2` is in  *Maintenance Support*, and `n-3` is *unsupported*. For more information please see [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)|
-|`(13)` &#124; Merative Social Program Management *only requires* Docker to build container images, Merative Social Program Management *does not require* Docker as a container runtime engine.|
-|`(14)` &#124; From Helm release `v3.7.0`, the ChartMuseum Push plugin to be used with Merative Social Program Management must be version `0.10.0` or greater|
 
 </AccordionItem>
 

--- a/src/pages/troubleshooting/must_gather.mdx
+++ b/src/pages/troubleshooting/must_gather.mdx
@@ -374,6 +374,40 @@ where the number of pods may vary depending on the number of replicas specified.
 
 Use the `kubctl logs` command to view the batch pod's stdout.
 
+For these pods the relevant log files can be found within the `/opt/ibm/Curam/release/buildlogs` folder of the pod’s file system
+
+Using the `kubectl exec` command as illustrated will place you into the pod:
+
+```
+kubectl exec --namespace <name_space> -it <batch_pod_name> -- /bin/bash
+```
+
+The log file is in `/opt/ibm/Curam/release/buildlogs/BatchLaucher123456789.log`.
+
+If the persistence volume is enabled to store data, it will be saved to the Azure blob storage account,
+
+in the "logs" directory within the pod's directory.
+
+If persistence is not enabled, the logs will be generated in the folder indicated above by default.
+
+Enabling persistence activates the parameter
+
+```
+-Ddir.bld.log=$MOUNT_POINT/$HOSTNAME/logs
+```
+
+In Batch, the -Ddir.bld.log option is used to specify a system property that defines the path to the directory where
+
+the build logs will be stored. This option is typically used in the context of build commands or automation scripts to
+
+dynamically configure properties without modifying configuration files.
+
+Configuring logs correctly is crucial for debugging and maintaining the build process.
+
+The -Ddir.bld.log option is a flexible and powerful way to dynamically configure the log directory for Batch build processes.
+
+$MOUNT_POINT/$HOSTNAME/logs is a folder created adhoc to store the logs in the Azure blob storage account.
+
 #### HTTP Server logs and artifacts
 
 The Apache HTTP Server is only used for hosting SPM static content this information would only be of interest for issues relating specifically to static content.


### PR DESCRIPTION
## v24.11.0

### Breaking Change

* To enable persistence and the capturing of metrics on the batch pods Batch.Dockerfile has been updated with the following
  * The Batch.Dockerfile was updated to copy `docker-server.sh` to allow scripts for persistence
  * Updated `helm-charts/batch/templates/cronjob-program.yaml` command and args to run `docker-server.sh` not updating charts for this Batch.Dockerfile will cause charts to fail
  * Helm charts updated kubeVersion from `">=1.20"` to `">=1.20 || >=1.30.0-eks-a737599"`

### Added

* Create `helm-charts/batch/templates/configmaps/configmap-jmx-batch-config.yaml` for JMX Exporter
* Update `config-reference` to allow `batch.jmxExporter.enabled` and `batch.jmxExporter.port` to be configured
* Support for future releases of OpenShift

### Changed

* Updated `helm-charts/batch/templates/cronjob-program.yaml` to allow batch launcher logs be persistent
* Updated `helm-charts/batch/templates/_helpers.tpl` for persistence
* Updated `helm-charts/batch/templates/cronjob-program.yaml` to allow JMX Exporting and persistence
* Updated `helm-charts/batch/values.yaml` for JMX Exporter
* Updated `batch` yaml for copyright changes
* The following helm-charts have been updated to chart version `24.11.0`: `apps`, `batch`, `mqserver`, `spm`, `uawebapp`, `web`, `xmlserver`
* Updated WebSphere Liberty version to include `24.0.0.6`
* Updated batch helm chart to read Java max memory from values file
* `ibmjava8-sdk-ubi8-minimal` updated to `8.0.30.0`