### PR TITLE
Cúram Release 8.2.2.0 - Patch Release-June-2026 v26.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file
 
+## v26.6.1
+
+### Fixed
+
+* **MQ deployment exclusion for BirtViewer:** Added `mqEnabled: false` flag for `curambirtviewer` application to prevent unnecessary MQ queue manager and pod deployment. BirtViewer is a read-only reporting application and does not require message queue infrastructure. Updated all `mqserver` chart templates to check the `mqEnabled` flag (defaults to `true` for other applications). Removed `curambirtviewer` DNS entry from MQ certificate configuration and renumbered DNS entries sequentially.
+
+### Changed
+
+* The following Helm charts have been updated to chart version `26.6.1`: `apps`, `batch`, `db2`, `dbbuild`, `mqserver`, `spm`, `uawebapp`, `web`, `xmlserver`.
+
 ## v26.6.0
 
 ### Breaking Changes

--- a/dockerfiles/Liberty/Java8/Batch.Dockerfile
+++ b/dockerfiles/Liberty/Java8/Batch.Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# © Merative US L.P. 2022,2025
+# © Merative US L.P. 2022,2026
 # Copyright 2020 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dockerfiles/Liberty/Java8/ClientEAR.Dockerfile
+++ b/dockerfiles/Liberty/Java8/ClientEAR.Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# © Merative US L.P. 2022,2025
+# © Merative US L.P. 2022,2026
 # Copyright 2020 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dockerfiles/Liberty/Java8/ServerEAR.Dockerfile
+++ b/dockerfiles/Liberty/Java8/ServerEAR.Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# © Merative US L.P. 2022,2025
+# © Merative US L.P. 2022,2026
 # Copyright 2020,2022 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dockerfiles/Liberty/Java8/Utilities.Dockerfile
+++ b/dockerfiles/Liberty/Java8/Utilities.Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# © Merative US L.P. 2022,2025
+# © Merative US L.P. 2022,2026
 # Copyright 2020 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dockerfiles/Liberty/Java8/XMLServer.Dockerfile
+++ b/dockerfiles/Liberty/Java8/XMLServer.Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# © Merative US L.P. 2022,2025
+# © Merative US L.P. 2022,2026
 # Copyright 2020,2022 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dockerfiles/Liberty/Java8/content/readiness-xmlserver.sh
+++ b/dockerfiles/Liberty/Java8/content/readiness-xmlserver.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ###############################################################################
-# © Merative US L.P. 2023,2025
+# © Merative US L.P. 2023,2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/Liberty/ModernJava/Batch.Dockerfile
+++ b/dockerfiles/Liberty/ModernJava/Batch.Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# © Merative US L.P. 2025
+# © Merative US L.P. 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/Liberty/ModernJava/ClientEAR.Dockerfile
+++ b/dockerfiles/Liberty/ModernJava/ClientEAR.Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# © Merative US L.P. 2025
+# © Merative US L.P. 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/Liberty/ModernJava/ServerEAR.Dockerfile
+++ b/dockerfiles/Liberty/ModernJava/ServerEAR.Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# © Merative US L.P. 2025
+# © Merative US L.P. 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/Liberty/ModernJava/Utilities.Dockerfile
+++ b/dockerfiles/Liberty/ModernJava/Utilities.Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# © Merative US L.P. 2025
+# © Merative US L.P. 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/Liberty/ModernJava/XMLServer.Dockerfile
+++ b/dockerfiles/Liberty/ModernJava/XMLServer.Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# © Merative US L.P. 2025
+# © Merative US L.P. 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/Liberty/ModernJava/content/readiness-xmlserver.sh
+++ b/dockerfiles/Liberty/ModernJava/content/readiness-xmlserver.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ###############################################################################
-# © Merative US L.P. 2025
+# © Merative US L.P. 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/helm-charts/apps/Chart.yaml
+++ b/helm-charts/apps/Chart.yaml
@@ -1,5 +1,5 @@
 ###############################################################################
-# © Merative US L.P. 2022,2025
+# © Merative US L.P. 2022,2026
 # Copyright 2019,2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,7 +31,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 26.6.0
+version: 26.6.1
 maintainers:
   - name: Cúram
   - name: Cúram Dev Team

--- a/helm-charts/apps/templates/configmaps/configmap-applications.yaml
+++ b/helm-charts/apps/templates/configmaps/configmap-applications.yaml
@@ -1,7 +1,7 @@
 {{- include "sch.config.init" (list . "apps.sch.chart.config.values") -}}
 ---
 ###############################################################################
-# © Merative US L.P. 2022,2025
+# © Merative US L.P. 2022,2026
 # Copyright 2019,2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/helm-charts/apps/templates/configmaps/configmap-jvm-options.yaml
+++ b/helm-charts/apps/templates/configmaps/configmap-jvm-options.yaml
@@ -1,7 +1,7 @@
 {{- include "sch.config.init" (list . "apps.sch.chart.config.values") -}}
 ---
 ###############################################################################
-# © Merative US L.P. 2022,2025
+# © Merative US L.P. 2022,2026
 # Copyright 2019,2020 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/helm-charts/apps/templates/configmaps/configmap-sessions.yaml
+++ b/helm-charts/apps/templates/configmaps/configmap-sessions.yaml
@@ -1,7 +1,7 @@
 {{- include "sch.config.init" (list . "apps.sch.chart.config.values") -}}
 ---
 ###############################################################################
-# © Merative US L.P. 2022,2025
+# © Merative US L.P. 2022,2026
 # Copyright 2019,2022 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/helm-charts/apps/values.yaml
+++ b/helm-charts/apps/values.yaml
@@ -1,5 +1,5 @@
 ###############################################################################
-# © Merative US L.P. 2022,2025
+# © Merative US L.P. 2022,2026
 # Copyright 2019,2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/helm-charts/batch/Chart.yaml
+++ b/helm-charts/batch/Chart.yaml
@@ -1,5 +1,5 @@
 ###############################################################################
-# © Merative US L.P. 2022,2025
+# © Merative US L.P. 2022,2026
 # Copyright 2019,2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,7 +30,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 26.6.0
+version: 26.6.1
 maintainers:
   - name: Cúram
   - name: Cúram Dev Team

--- a/helm-charts/mqserver/Chart.yaml
+++ b/helm-charts/mqserver/Chart.yaml
@@ -1,5 +1,5 @@
 ###############################################################################
-# © Merative US L.P. 2022,2025
+# © Merative US L.P. 2022,2026
 # Copyright 2019,2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,7 +31,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 26.6.0
+version: 26.6.1
 maintainers:
   - name: Cúram
   - name: Cúram Dev Team

--- a/helm-charts/mqserver/templates/configmap-metrics.yaml
+++ b/helm-charts/mqserver/templates/configmap-metrics.yaml
@@ -2,7 +2,7 @@
 {{- include "sch.config.init" (list . "mqserver.sch.chart.config.values") -}}
 ---
 ###############################################################################
-# © Merative US L.P. 2022,2025
+# © Merative US L.P. 2022,2026
 # Copyright 2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/helm-charts/mqserver/templates/configmap-mqsc.yaml
+++ b/helm-charts/mqserver/templates/configmap-mqsc.yaml
@@ -1,7 +1,7 @@
 {{- include "sch.config.init" (list . "mqserver.sch.chart.config.values") -}}
 ---
 ###############################################################################
-# © Merative US L.P. 2022,2025
+# © Merative US L.P. 2022,2026
 # Copyright 2019,2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -74,7 +74,7 @@ data:
 
 {{ $apps := .Values.global.apps.config }}
 {{- range $name, $app := $apps }}
-{{- if and ($app.enabled) (not (hasKey $app "mqConnectionNameList")) }}
+{{- if and ($app.enabled) (ne ($app.mqEnabled | default true) false) (not (hasKey $app "mqConnectionNameList")) }}
   channel_{{$name}}.mqsc: |
     DEFINE CHANNEL(MQ_CHN_PROD) CHLTYPE(CLNTCONN) TRPTYPE(TCP) CONNAME('{{ $.Release.Name }}-mqserver-{{ $name }}') QMNAME({{ $.Values.global.mq.queueManager.name }}) SSLCIPH(ECDHE_RSA_AES_128_CBC_SHA256) CERTLABL ('ibmwebspheremq{{ $.Values.global.mq.queueManager.name | lower }}') REPLACE
     DEFINE CHANNEL(MQ_CHN_CONS) CHLTYPE(CLNTCONN) TRPTYPE(TCP) CONNAME('{{ $.Release.Name }}-mqserver-{{ $name }}') QMNAME({{ $.Values.global.mq.queueManager.name }}) SSLCIPH(ECDHE_RSA_AES_128_CBC_SHA256) CERTLABL ('ibmwebspheremq{{ $.Values.global.mq.queueManager.name | lower }}') REPLACE

--- a/helm-charts/mqserver/templates/deployment-metrics.yaml
+++ b/helm-charts/mqserver/templates/deployment-metrics.yaml
@@ -2,10 +2,10 @@
 {{- include "sch.config.init" (list . "mqserver.sch.chart.config.values") -}}
 {{ $apps := .Values.global.apps.config }}
 {{- range $name, $app := $apps }}
-{{- if and ($app.enabled) (not (hasKey $app "mqConnectionNameList")) }}
+{{- if and ($app.enabled) (ne ($app.mqEnabled | default true) false) (not (hasKey $app "mqConnectionNameList")) }}
 ---
 ###############################################################################
-# © Merative US L.P. 2022,2025
+# © Merative US L.P. 2022,2026
 # Copyright 2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/helm-charts/mqserver/templates/deployment.yaml
+++ b/helm-charts/mqserver/templates/deployment.yaml
@@ -2,11 +2,11 @@
 {{- if (not (.Capabilities.APIVersions.Has "mq.ibm.com/v1beta1")) }}
 {{ $apps := .Values.global.apps.config }}
 {{- range $name, $app := $apps }}
-{{- if and ($app.enabled) (not (hasKey $app "mqConnectionNameList")) }}
+{{- if and ($app.enabled) (ne ($app.mqEnabled | default true) false) (not (hasKey $app "mqConnectionNameList")) }}
 {{- $tuningParams := $app.mqTuning }}
 ---
 ###############################################################################
-# © Merative US L.P. 2022,2025
+# © Merative US L.P. 2022,2026
 # Copyright 2019,2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/helm-charts/mqserver/templates/hooks/hook-configmap-mq-cert.yaml
+++ b/helm-charts/mqserver/templates/hooks/hook-configmap-mq-cert.yaml
@@ -2,7 +2,7 @@
 {{- include "sch.config.init" (list . "mqserver.sch.chart.config.values") -}}
 ---
 ###############################################################################
-# © Merative US L.P. 2025
+# © Merative US L.P. 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,13 +44,12 @@ data:
     [ alt_names ]
     DNS.1 = {{ .Release.Name }}-mqserver-curam
     DNS.2 = {{ .Release.Name }}-mqserver-rest
-    DNS.3 = {{ .Release.Name }}-mqserver-curambirtviewer
-    DNS.4 = {{ .Release.Name }}-mqserver-citizenportal
-    DNS.5 = {{ .Release.Name }}-mqserver-curamwebservices
-    DNS.6 = {{ .Release.Name }}-mqserver-cpmexternalns
-    DNS.7 = {{ .Release.Name }}-mqserver-cpmexternals
-    DNS.8 = {{ .Release.Name }}-mqserver-navigatorns
-    DNS.9 = {{ .Release.Name }}-mqserver-navigators
-    DNS.10 = {{ .Release.Name }}-mqserver-mdtworkspace
-    DNS.11 = {{ .Release.Name }}-mqserver-samplepublicaccess
+    DNS.3 = {{ .Release.Name }}-mqserver-citizenportal
+    DNS.4 = {{ .Release.Name }}-mqserver-curamwebservices
+    DNS.5 = {{ .Release.Name }}-mqserver-cpmexternalns
+    DNS.6 = {{ .Release.Name }}-mqserver-cpmexternals
+    DNS.7 = {{ .Release.Name }}-mqserver-navigatorns
+    DNS.8 = {{ .Release.Name }}-mqserver-navigators
+    DNS.9 = {{ .Release.Name }}-mqserver-mdtworkspace
+    DNS.10 = {{ .Release.Name }}-mqserver-samplepublicaccess
 {{- end }}

--- a/helm-charts/mqserver/templates/monitor-mqserver.yaml
+++ b/helm-charts/mqserver/templates/monitor-mqserver.yaml
@@ -2,10 +2,10 @@
 {{- if and .Values.global.mq.metrics.enabled .Values.global.mq.metrics.additionalMetrics }}
 {{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
 {{- range $name, $app := .Values.global.apps.config }}
-{{- if and ($app.enabled) (not (hasKey $app "mqConnectionNameList")) }}
+{{- if and ($app.enabled) (ne ($app.mqEnabled | default true) false) (not (hasKey $app "mqConnectionNameList")) }}
 ---
 ###############################################################################
-# © Merative US L.P. 2022,2025
+# © Merative US L.P. 2022,2026
 # Copyright 2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/helm-charts/mqserver/templates/queue-manager.yaml
+++ b/helm-charts/mqserver/templates/queue-manager.yaml
@@ -2,11 +2,11 @@
 {{- if (.Capabilities.APIVersions.Has "mq.ibm.com/v1beta1") }}
 {{ $apps := .Values.global.apps.config }}
 {{- range $name, $app := $apps }}
-{{- if and ($app.enabled) (not (hasKey $app "mqConnectionNameList")) }}
+{{- if and ($app.enabled) (ne ($app.mqEnabled | default true) false) (not (hasKey $app "mqConnectionNameList")) }}
 {{- $tuningParams := $app.mqTuning }}
 ---
 ###############################################################################
-# © Merative US L.P. 2022,2025
+# © Merative US L.P. 2022,2026
 # Copyright 2019,2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/helm-charts/mqserver/templates/service.yaml
+++ b/helm-charts/mqserver/templates/service.yaml
@@ -1,10 +1,10 @@
 {{- include "sch.config.init" (list . "mqserver.sch.chart.config.values") -}}
 {{- if not (.Capabilities.APIVersions.Has "mq.ibm.com/v1beta1") }}
 {{- range $name, $app := .Values.global.apps.config }}
-{{- if and ($app.enabled) (not (hasKey $app "mqConnectionNameList")) }}
+{{- if and ($app.enabled) (ne ($app.mqEnabled | default true) false) (not (hasKey $app "mqConnectionNameList")) }}
 ---
 ###############################################################################
-# © Merative US L.P. 2022,2025
+# © Merative US L.P. 2022,2026
 # Copyright 2019,2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/helm-charts/mqserver/values.yaml
+++ b/helm-charts/mqserver/values.yaml
@@ -1,5 +1,5 @@
 ###############################################################################
-# © Merative US L.P. 2022,2025
+# © Merative US L.P. 2022,2026
 # Copyright 2019,2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,6 +46,7 @@ global:
         mqTuning: {}
       curambirtviewer:
         enabled: false
+        mqEnabled: false
         mqTuning: {}
       cpmexternalns:
         enabled: false

--- a/helm-charts/spm/Chart.yaml
+++ b/helm-charts/spm/Chart.yaml
@@ -1,5 +1,5 @@
 ###############################################################################
-# © Merative US L.P. 2022,2025
+# © Merative US L.P. 2022,2026
 # Copyright 2019,2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,7 +31,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 26.6.0
+version: 26.6.1
 maintainers:
   - name: Cúram
   - name: Cúram Dev Team
@@ -57,22 +57,22 @@ icon: https://avatars2.githubusercontent.com/u/1459110
 
 dependencies:
   - name: apps
-    version: "~26.6.0"
+    version: "~26.6.1"
     repository: "@local-development"
   - name: batch
-    version: "~26.6.0"
+    version: "~26.6.1"
     repository: "@local-development"
   - name: uawebapp
-    version: "~26.6.0"
+    version: "~26.6.1"
     repository: "@local-development"
   - name: web
-    version: "~26.6.0"
+    version: "~26.6.1"
     repository: "@local-development"
   - name: mqserver
-    version: "~26.6.0"
+    version: "~26.6.1"
     repository: "@local-development"
   - name: xmlserver
-    version: "~26.6.0"
+    version: "~26.6.1"
     repository: "@local-development"
   - name: ibm-sch
     repository: "@sch"

--- a/helm-charts/spm/values.yaml
+++ b/helm-charts/spm/values.yaml
@@ -1,5 +1,5 @@
 ###############################################################################
-# © Merative US L.P. 2022,2025
+# © Merative US L.P. 2022,2026
 # Copyright 2019,2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -140,6 +140,7 @@ global:
           - "-Xmx512m"
       curambirtviewer:
         enabled: false
+        mqEnabled: false
         replicaCount: 1
         readinessTCPProbe: true
         ingressPath: /CuramBIRTViewer/

--- a/helm-charts/uawebapp/Chart.yaml
+++ b/helm-charts/uawebapp/Chart.yaml
@@ -1,5 +1,5 @@
 ###############################################################################
-# © Merative US L.P. 2022,2025
+# © Merative US L.P. 2022,2026
 # Copyright 2019,2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,7 +31,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 26.6.0
+version: 26.6.1
 maintainers:
   - name: Cúram
   - name: Cúram Dev Team

--- a/helm-charts/web/Chart.yaml
+++ b/helm-charts/web/Chart.yaml
@@ -1,5 +1,5 @@
 ###############################################################################
-# © Merative US L.P. 2022,2025
+# © Merative US L.P. 2022,2026
 # Copyright 2019,2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,7 +31,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 26.6.0
+version: 26.6.1
 maintainers:
   - name: Cúram
   - name: Cúram Dev Team

--- a/helm-charts/xmlserver/Chart.yaml
+++ b/helm-charts/xmlserver/Chart.yaml
@@ -1,5 +1,5 @@
 ###############################################################################
-# © Merative US L.P. 2022,2025
+# © Merative US L.P. 2022,2026
 # Copyright 2019,2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,7 +31,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 26.6.0
+version: 26.6.1
 maintainers:
   - name: Cúram
   - name: Cúram Dev Team

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "curam-kubernetes",
-  "version": "26.6.0",
+  "version": "26.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "curam-kubernetes",
-      "version": "26.6.0",
+      "version": "26.6.1",
       "license": "Apache 2.0",
       "dependencies": {
         "@carbon/icons-react": "^11.36.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "curam-kubernetes",
   "private": true,
-  "version": "26.6.0",
+  "version": "26.6.1",
   "license": "Apache 2.0",
   "scripts": {
     "dev": "gatsby develop -H 0.0.0.0",

--- a/src/pages/prereq/ingress.mdx
+++ b/src/pages/prereq/ingress.mdx
@@ -89,6 +89,12 @@ This section is for clients migrating from the community `ingress-nginx` control
 
 The Helm chart retains the community `ingress-nginx` annotations for backwards compatibility and includes the F5 equivalents commented out. When you are ready to migrate, replace the community annotations with the F5 equivalents as shown below.
 
+<InlineNotification>
+
+**Note:** F5 NGINX uses two annotation namespaces. `nginx.org/` is used for F5-specific features such as SSL services and session persistence. `nginx.org/` is used for standard NGINX configuration such as timeouts and server snippets. Both are required as part of a full migration.
+
+</InlineNotification>
+
 **Before (community `ingress-nginx`)**
 
 ```yaml

--- a/static/resources/aks-values.yaml
+++ b/static/resources/aks-values.yaml
@@ -62,6 +62,7 @@ global:
     #     enabled: false
     #   curambirtviewer:
     #     enabled: false
+    #     mqEnabled: false
 
   ## Set to use xmlserver monitoring
   useBetaFeatures: false

--- a/static/resources/crc-values.yaml
+++ b/static/resources/crc-values.yaml
@@ -60,6 +60,7 @@ global:
   #       enabled: false
   #     curambirtviewer:
   #       enabled: false
+  #       mqEnabled: false
 
   ## Set to use xmlserver monitoring
   useBetaFeatures: false

--- a/static/resources/minikube-values.yaml
+++ b/static/resources/minikube-values.yaml
@@ -58,6 +58,7 @@ global:
     #     enabled: false
     #   curambirtviewer:
     #     enabled: false
+    #     mqEnabled: false
 
   ## Set to use xmlserver monitoring
   useBetaFeatures: false

--- a/static/resources/tuning-values.yaml
+++ b/static/resources/tuning-values.yaml
@@ -194,6 +194,7 @@ global:
     #     enabled: false
     #   curambirtviewer:
     #     enabled: false
+    #     mqEnabled: false
 
   ## Set to use xmlserver monitoring
   useBetaFeatures: false


### PR DESCRIPTION
## v26.6.1

### Fixed

* **MQ deployment exclusion for BirtViewer:** Added `mqEnabled: false` flag for `curambirtviewer` application to prevent unnecessary MQ queue manager and pod deployment. BirtViewer is a read-only reporting application and does not require message queue infrastructure. Updated all `mqserver` chart templates to check the `mqEnabled` flag (defaults to `true` for other applications). Removed `curambirtviewer` DNS entry from MQ certificate configuration and renumbered DNS entries sequentially.

### Changed

* The following Helm charts have been updated to chart version `26.6.1`: `apps`, `batch`, `db2`, `dbbuild`, `mqserver`, `spm`, `uawebapp`, `web`, `xmlserver`.
